### PR TITLE
feat: フォーム管理ライブラリ導入・アクセシビリティ改善

### DIFF
--- a/app/form-demo/page.tsx
+++ b/app/form-demo/page.tsx
@@ -1,0 +1,242 @@
+'use client'
+
+import React, { useState } from 'react'
+
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Controller, useForm } from 'react-hook-form'
+import { z } from 'zod'
+
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { FormFieldWrapper } from '@/components/ui/form-field'
+import { Input } from '@/components/ui/input'
+import { commonValidationSchemas } from '@/lib/shared/forms'
+
+// フォームのバリデーションスキーマ
+const demoFormSchema = z.object({
+  name: commonValidationSchemas.requiredString('名前'),
+  email: commonValidationSchemas.email,
+  phone: commonValidationSchemas.phoneNumber,
+  website: commonValidationSchemas.url,
+})
+
+type DemoFormData = z.infer<typeof demoFormSchema>
+
+export default function FormDemoPage() {
+  const [submitError, setSubmitError] = useState<string>()
+  const [submitSuccess, setSubmitSuccess] = useState(false)
+
+  const form = useForm<DemoFormData>({
+    resolver: zodResolver(demoFormSchema),
+    defaultValues: {
+      name: '',
+      email: '',
+      phone: '',
+      website: '',
+    },
+    mode: 'onBlur',
+  })
+
+  const {
+    control,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting, isValid, isDirty }
+  } = form
+
+  const onSubmit = async (data: DemoFormData) => {
+    try {
+      setSubmitError(undefined)
+      setSubmitSuccess(false)
+      
+      // シミュレートされた送信処理
+      await new Promise((resolve, reject) => {
+        setTimeout(() => {
+          // 10%の確率でエラーをシミュレート
+          if (Math.random() < 0.1) {
+            reject(new Error('サーバーエラーが発生しました'))
+          } else {
+            resolve(undefined)
+          }
+        }, 1000)
+      })
+      
+      console.log('フォームデータ:', data)
+      setSubmitSuccess(true)
+      
+      // 3秒後に成功メッセージを自動で非表示
+      setTimeout(() => setSubmitSuccess(false), 3000)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'エラーが発生しました'
+      setSubmitError(message)
+    }
+  }
+
+  const handleReset = () => {
+    reset({
+      name: '',
+      email: '',
+      phone: '',
+      website: '',
+    })
+    setSubmitError(undefined)
+    setSubmitSuccess(false)
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-12">
+      <div className="max-w-md mx-auto">
+        <Card className="p-6">
+          <div className="mb-6">
+            <h1 className="text-2xl font-bold text-gray-900">フォームデモ</h1>
+            <p className="text-gray-600 mt-2">
+              react-hook-form と zod を使用したフォーム例
+            </p>
+          </div>
+
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+            {/* 基本情報 */}
+            <div className="space-y-4">
+              <h3 className="text-lg font-semibold text-gray-900">基本情報</h3>
+              
+              {/* 名前 */}
+              <Controller
+                control={control}
+                name="name"
+                render={({ field }) => (
+                  <FormFieldWrapper
+                    label="名前"
+                    required
+                    error={errors.name?.message}
+                  >
+                    <Input
+                      {...field}
+                      placeholder="田中太郎"
+                      disabled={isSubmitting}
+                      onChange={(e) => field.onChange(e.target.value)}
+                    />
+                  </FormFieldWrapper>
+                )}
+              />
+
+              {/* メールアドレス */}
+              <Controller
+                control={control}
+                name="email"
+                render={({ field }) => (
+                  <FormFieldWrapper
+                    label="メールアドレス"
+                    required
+                    error={errors.email?.message}
+                  >
+                    <Input
+                      {...field}
+                      type="email"
+                      placeholder="example@example.com"
+                      disabled={isSubmitting}
+                      onChange={(e) => field.onChange(e.target.value)}
+                    />
+                  </FormFieldWrapper>
+                )}
+              />
+            </div>
+
+            {/* 連絡先（任意） */}
+            <div className="space-y-4">
+              <h3 className="text-lg font-semibold text-gray-900">連絡先（任意）</h3>
+              
+              {/* 電話番号 */}
+              <Controller
+                control={control}
+                name="phone"
+                render={({ field }) => (
+                  <FormFieldWrapper
+                    label="電話番号"
+                    error={errors.phone?.message}
+                    description="ハイフンありまたはなしで入力してください"
+                  >
+                    <Input
+                      {...field}
+                      placeholder="090-1234-5678"
+                      disabled={isSubmitting}
+                      onChange={(e) => field.onChange(e.target.value)}
+                    />
+                  </FormFieldWrapper>
+                )}
+              />
+
+              {/* ウェブサイト */}
+              <Controller
+                control={control}
+                name="website"
+                render={({ field }) => (
+                  <FormFieldWrapper
+                    label="ウェブサイト"
+                    error={errors.website?.message}
+                    description="https://から始まるURLを入力してください"
+                  >
+                    <Input
+                      {...field}
+                      placeholder="https://example.com"
+                      disabled={isSubmitting}
+                      onChange={(e) => field.onChange(e.target.value)}
+                    />
+                  </FormFieldWrapper>
+                )}
+              />
+            </div>
+
+            {/* 送信結果メッセージ */}
+            {submitSuccess && (
+              <div className="p-4 bg-green-50 border border-green-200 rounded-md animate-in fade-in-0 slide-in-from-top-2">
+                <p className="text-green-800 text-sm font-medium">
+                  ✓ フォームが正常に送信されました！
+                </p>
+              </div>
+            )}
+            
+            {submitError && (
+              <div className="p-4 bg-red-50 border border-red-200 rounded-md animate-in fade-in-0 slide-in-from-top-2">
+                <p className="text-red-800 text-sm font-medium">
+                  ✗ {submitError}
+                </p>
+              </div>
+            )}
+
+            {/* アクション */}
+            <div className="flex justify-end gap-3 pt-4">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleReset}
+                disabled={isSubmitting}
+              >
+                リセット
+              </Button>
+              <Button
+                type="submit"
+                disabled={isSubmitting || !isValid}
+                className={isSubmitting ? 'cursor-wait' : ''}
+              >
+                {isSubmitting && (
+                  <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2" />
+                )}
+                {isSubmitting ? '送信中...' : '送信'}
+              </Button>
+            </div>
+          </form>
+
+          {/* フォーム状態表示 */}
+          <div className="mt-6 p-4 bg-gray-100 rounded">
+            <h3 className="font-semibold text-sm text-gray-700 mb-2">フォーム状態</h3>
+            <ul className="text-xs text-gray-600 space-y-1">
+              <li>有効: {isValid ? 'はい' : 'いいえ'}</li>
+              <li>変更済み: {isDirty ? 'はい' : 'いいえ'}</li>
+              <li>送信中: {isSubmitting ? 'はい' : 'いいえ'}</li>
+            </ul>
+          </div>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/app/form-demo/page.tsx
+++ b/app/form-demo/page.tsx
@@ -106,11 +106,13 @@ export default function FormDemoPage() {
                 render={({ field }) => (
                   <FormFieldWrapper
                     label="名前"
+                    id="name"
                     required
                     error={errors.name?.message}
                   >
                     <Input
                       {...field}
+                      id="name"
                       placeholder="田中太郎"
                       disabled={isSubmitting}
                       onChange={(e) => field.onChange(e.target.value)}
@@ -126,11 +128,13 @@ export default function FormDemoPage() {
                 render={({ field }) => (
                   <FormFieldWrapper
                     label="メールアドレス"
+                    id="email"
                     required
                     error={errors.email?.message}
                   >
                     <Input
                       {...field}
+                      id="email"
                       type="email"
                       placeholder="example@example.com"
                       disabled={isSubmitting}
@@ -152,11 +156,13 @@ export default function FormDemoPage() {
                 render={({ field }) => (
                   <FormFieldWrapper
                     label="電話番号"
+                    id="phone"
                     error={errors.phone?.message}
                     description="ハイフンありまたはなしで入力してください"
                   >
                     <Input
                       {...field}
+                      id="phone"
                       placeholder="090-1234-5678"
                       disabled={isSubmitting}
                       onChange={(e) => field.onChange(e.target.value)}
@@ -172,11 +178,13 @@ export default function FormDemoPage() {
                 render={({ field }) => (
                   <FormFieldWrapper
                     label="ウェブサイト"
+                    id="website"
                     error={errors.website?.message}
                     description="https://から始まるURLを入力してください"
                   >
                     <Input
                       {...field}
+                      id="website"
                       placeholder="https://example.com"
                       disabled={isSubmitting}
                       onChange={(e) => field.onChange(e.target.value)}

--- a/components/ui/form-field.tsx
+++ b/components/ui/form-field.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+
+import { cn } from '@/lib/shared/utils/ui'
+
+export interface FormFieldWrapperProps {
+  label: string
+  required?: boolean
+  error?: string
+  description?: string
+  className?: string
+  children: React.ReactNode
+}
+
+export function FormFieldWrapper({
+  label,
+  required = false,
+  error,
+  description,
+  className,
+  children
+}: FormFieldWrapperProps) {
+  return (
+    <div className={cn('space-y-2', className)}>
+      <label className="text-sm font-medium text-gray-700">
+        {label}
+        {required && <span className="text-red-500 ml-1">*</span>}
+      </label>
+      {description && (
+        <p className="text-sm text-gray-500">{description}</p>
+      )}
+      {children}
+      {error && (
+        <p className="text-sm text-red-600 animate-in fade-in-0 slide-in-from-top-1">
+          {error}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/components/ui/form-field.tsx
+++ b/components/ui/form-field.tsx
@@ -4,6 +4,7 @@ import { cn } from '@/lib/shared/utils/ui'
 
 export interface FormFieldWrapperProps {
   label: string
+  id?: string
   required?: boolean
   error?: string
   description?: string
@@ -13,6 +14,7 @@ export interface FormFieldWrapperProps {
 
 export function FormFieldWrapper({
   label,
+  id,
   required = false,
   error,
   description,
@@ -21,7 +23,7 @@ export function FormFieldWrapper({
 }: FormFieldWrapperProps) {
   return (
     <div className={cn('space-y-2', className)}>
-      <label className="text-sm font-medium text-gray-700">
+      <label htmlFor={id} className="text-sm font-medium text-gray-700">
         {label}
         {required && <span className="text-red-500 ml-1">*</span>}
       </label>

--- a/lib/shared/forms.ts
+++ b/lib/shared/forms.ts
@@ -15,7 +15,7 @@ export const commonValidationSchemas = {
   // メールアドレス
   email: z.string()
     .min(1, 'メールアドレスは必須項目です')
-    .email('有効なメールアドレスを入力してください'),
+    .pipe(z.email({ message: '有効なメールアドレスを入力してください' })),
 
   // 電話番号（日本の形式）
   phoneNumber: z.string()
@@ -42,6 +42,6 @@ export const commonValidationSchemas = {
   // URL
   url: z.string()
     .optional()
-    .refine((val) => !val || val === '' || z.string().url().safeParse(val).success, 
-      '有効なURLを入力してください'),
+    .transform(val => val === '' ? undefined : val)
+    .pipe(z.url({ message: '有効なURLを入力してください' }).optional()),
 }

--- a/lib/shared/forms.ts
+++ b/lib/shared/forms.ts
@@ -20,7 +20,7 @@ export const commonValidationSchemas = {
   // 電話番号（日本の形式）
   phoneNumber: z.string()
     .optional()
-    .refine((val) => !val || val === '' || /^0\d{1,4}-\d{1,4}-\d{4}$|^0\d{9,10}$/.test(val), 
+    .refine((val) => !val || val === '' || /^(?:0\d{9,10}|0\d{1,4}-\d{1,4}-\d{3,4})$/.test(val), 
       '有効な電話番号を入力してください'),
 
   // 郵便番号（日本の形式）

--- a/lib/shared/forms.ts
+++ b/lib/shared/forms.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod'
+
+/**
+ * フォーム管理の共通バリデーションスキーマ
+ */
+
+// 共通バリデーションスキーマ
+export const commonValidationSchemas = {
+  // 必須文字列（空文字不可）
+  requiredString: (fieldName: string) => 
+    z.string()
+      .min(1, `${fieldName}は必須項目です`)
+      .trim(),
+
+  // メールアドレス
+  email: z.string()
+    .min(1, 'メールアドレスは必須項目です')
+    .email('有効なメールアドレスを入力してください'),
+
+  // 電話番号（日本の形式）
+  phoneNumber: z.string()
+    .optional()
+    .refine((val) => !val || val === '' || /^0\d{1,4}-\d{1,4}-\d{4}$|^0\d{9,10}$/.test(val), 
+      '有効な電話番号を入力してください'),
+
+  // 郵便番号（日本の形式）
+  postalCode: z.string()
+    .optional()
+    .refine((val) => !val || val === '' || /^\d{3}-\d{4}$/.test(val), 
+      '郵便番号は000-0000の形式で入力してください'),
+
+  // 金額（正の数）
+  amount: z.number()
+    .positive('金額は0より大きい値を入力してください')
+    .max(999999999, '金額が上限を超えています'),
+
+  // 日付
+  date: z.date({
+    message: '有効な日付を入力してください',
+  }),
+
+  // URL
+  url: z.string()
+    .optional()
+    .refine((val) => !val || val === '' || z.string().url().safeParse(val).success, 
+      '有効なURLを入力してください'),
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@clerk/nextjs": "^6.25.0",
+        "@hookform/resolvers": "^5.1.1",
         "@prisma/client": "^6.11.1",
         "@radix-ui/react-slot": "^1.2.3",
         "class-variance-authority": "^0.7.1",
@@ -17,7 +18,9 @@
         "next": "15.3.5",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "tailwind-merge": "^3.3.1"
+        "react-hook-form": "^7.60.0",
+        "tailwind-merge": "^3.3.1",
+        "zod": "^4.0.5"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -346,6 +349,18 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.1.1.tgz",
+      "integrity": "sha512-J/NVING3LMAEvexJkyTLjruSm7aOFx7QX21pzkiJfMoNG0wl5aFEjLTl7ay7IQb9EWY6AkrBy7tHL2Alijpdcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1222,6 +1237,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
       "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@swc/counter": {
@@ -5496,6 +5517,22 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.60.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.60.0.tgz",
+      "integrity": "sha512-SBrYOvMbDB7cV8ZfNpaiLcgjH/a1c7aK0lK+aNigpf4xWLO8q+o4tcvVurv3c4EOyzn/3dCsYt4GKD42VvJ/+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -6658,6 +6695,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.5.tgz",
+      "integrity": "sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^6.25.0",
+    "@hookform/resolvers": "^5.1.1",
     "@prisma/client": "^6.11.1",
     "@radix-ui/react-slot": "^1.2.3",
     "class-variance-authority": "^0.7.1",
@@ -22,7 +23,9 @@
     "next": "15.3.5",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "tailwind-merge": "^3.3.1"
+    "react-hook-form": "^7.60.0",
+    "tailwind-merge": "^3.3.1",
+    "zod": "^4.0.5"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## 概要
- react-hook-form + zodによるフォーム管理ライブラリ導入
- 共通バリデーションスキーマとFormFieldWrapperコンポーネント追加
- アクセシビリティ対応とZod非推奨警告修正

## 背景
- フォーム管理の標準化とバリデーション処理の統一が必要だったため
- アクセシビリティ対応（label-input関連付け）が不足していたため
- Zodの新バージョンで非推奨警告が発生していたため

## 実装内容
- react-hook-form、zod、@hookform/resolversを導入
- 共通バリデーションスキーマ（メール、電話番号、URL等）実装
- FormFieldWrapperコンポーネント（エラー表示、必須マーク対応）
- labelのhtmlFor属性で入力要素と適切に関連付け
- z.string().email()をz.email()に変更してZod非推奨警告修正
- /form-demoデモページで動作確認機能を実装

## チェックリスト（必須確認事項）
- [x] 関連Issueにリンクされている
- [x] CIが通過している（test / lint / build）
- [x] 本番環境に影響がないことを確認済み
- [x] UI/UX上の重大な変更がある場合、他メンバーと共有済み
- [x] テストコードが追加 or テスト不要の理由を明記した

## 関連Issue / PR
- Close #3

## 補足
- react-hook-form、zod共に業界標準ライブラリで十分テスト済み
- FormFieldWrapperは基本的なラッパーコンポーネントのため単体テスト不要
- デモページで実際の動作確認を実装済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * バリデーション付きフォームのデモページを追加しました。名前、メール、電話番号、ウェブサイトの入力が可能です。
  * 入力エラーや送信成功・失敗時のメッセージ表示、リセット機能、送信中のスピナー表示など、ユーザー体験を向上させるUIを実装しました。
  * 共通バリデーションスキーマを導入し、複数の入力形式に対応しました。

* **ドキュメント**
  * フォームフィールド用のラッパーコンポーネントを追加し、ラベルやエラーメッセージの表示を統一しました。

* **チョア**
  * 必要なライブラリ（react-hook-form、zod等）を依存関係に追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->