### PR TITLE
feat: 会社情報CRUD API実装・バリデーション共通化・エラーハンドリング統一

### DIFF
--- a/app/api/companies/[id]/route.ts
+++ b/app/api/companies/[id]/route.ts
@@ -37,8 +37,8 @@ export async function PUT(request: NextRequest, context: RouteContext) {
     }
 
     const filteredData = Object.fromEntries(
-      Object.entries(validatedData).filter(([, value]) => value !== undefined)
-    );
+      Object.entries(validatedData).filter(([_, value]) => value !== undefined)
+    ) as Partial<typeof validatedData>;
 
     const updatedCompany = await prisma.company.update({
       where: { id },

--- a/app/api/companies/[id]/route.ts
+++ b/app/api/companies/[id]/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { auth } from '@clerk/nextjs/server';
+import { z } from 'zod';
+
+import { apiErrors, companySchemas } from '@/lib/shared/forms';
+import { prisma } from '@/lib/shared/prisma';
+
+interface RouteContext {
+  params: Promise<{ id: string }>;
+}
+
+export async function PUT(request: NextRequest, context: RouteContext) {
+  try {
+    const { userId } = await auth();
+
+    if (!userId) {
+      return NextResponse.json(apiErrors.unauthorized(), { status: 401 });
+    }
+
+    const { id } = await context.params;
+    const body = await request.json();
+    const validatedData = companySchemas.update.parse(body);
+
+    const existingCompany = await prisma.company.findUnique({
+      where: { id },
+    });
+
+    if (!existingCompany) {
+      return NextResponse.json(apiErrors.notFound('会社情報'), { status: 404 });
+    }
+
+    if (existingCompany.userId !== userId) {
+      return NextResponse.json(apiErrors.forbidden(), { status: 403 });
+    }
+
+    const filteredData = Object.fromEntries(
+      Object.entries(validatedData).filter(([, value]) => value !== undefined)
+    );
+
+    const updatedCompany = await prisma.company.update({
+      where: { id },
+      data: filteredData,
+    });
+
+    return NextResponse.json(updatedCompany);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(apiErrors.validation(error.issues), {
+        status: 400,
+      });
+    }
+
+    console.error('Company update error:', error);
+    return NextResponse.json(apiErrors.internal(), { status: 500 });
+  }
+}
+
+export async function DELETE(_request: NextRequest, context: RouteContext) {
+  try {
+    const { userId } = await auth();
+
+    if (!userId) {
+      return NextResponse.json(apiErrors.unauthorized(), { status: 401 });
+    }
+
+    const { id } = await context.params;
+
+    const existingCompany = await prisma.company.findUnique({
+      where: { id },
+    });
+
+    if (!existingCompany) {
+      return NextResponse.json(apiErrors.notFound('会社情報'), { status: 404 });
+    }
+
+    if (existingCompany.userId !== userId) {
+      return NextResponse.json(apiErrors.forbidden(), { status: 403 });
+    }
+
+    await prisma.company.delete({
+      where: { id },
+    });
+
+    return NextResponse.json(
+      { message: '会社情報を削除しました' },
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error('Company delete error:', error);
+    return NextResponse.json(apiErrors.internal(), { status: 500 });
+  }
+}

--- a/app/api/companies/route.ts
+++ b/app/api/companies/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { auth } from '@clerk/nextjs/server';
+import { z } from 'zod';
+
+import { apiErrors, companySchemas } from '@/lib/shared/forms';
+import { prisma } from '@/lib/shared/prisma';
+
+export async function POST(request: NextRequest) {
+  try {
+    const { userId } = await auth();
+
+    if (!userId) {
+      return NextResponse.json(apiErrors.unauthorized(), { status: 401 });
+    }
+
+    const body = await request.json();
+    const validatedData = companySchemas.create.parse(body);
+
+    const existingCompany = await prisma.company.findUnique({
+      where: { userId },
+    });
+
+    if (existingCompany) {
+      return NextResponse.json(
+        apiErrors.conflict('会社情報は既に登録されています'),
+        { status: 400 }
+      );
+    }
+
+    const company = await prisma.company.create({
+      data: {
+        ...validatedData,
+        userId,
+      },
+    });
+
+    return NextResponse.json(company, { status: 201 });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(apiErrors.validation(error.issues), {
+        status: 400,
+      });
+    }
+
+    console.error('Company creation error:', error);
+    return NextResponse.json(apiErrors.internal(), { status: 500 });
+  }
+}
+
+export async function GET() {
+  try {
+    const { userId } = await auth();
+
+    if (!userId) {
+      return NextResponse.json(apiErrors.unauthorized(), { status: 401 });
+    }
+
+    const company = await prisma.company.findUnique({
+      where: { userId },
+    });
+
+    if (!company) {
+      return NextResponse.json(apiErrors.notFound('会社情報'), { status: 404 });
+    }
+
+    return NextResponse.json(company);
+  } catch (error) {
+    console.error('Company fetch error:', error);
+    return NextResponse.json(apiErrors.internal(), { status: 500 });
+  }
+}

--- a/app/api/companies/route.ts
+++ b/app/api/companies/route.ts
@@ -24,7 +24,7 @@ export async function POST(request: NextRequest) {
     if (existingCompany) {
       return NextResponse.json(
         apiErrors.conflict('会社情報は既に登録されています'),
-        { status: 400 }
+        { status: 409 }
       );
     }
 

--- a/lib/shared/forms.ts
+++ b/lib/shared/forms.ts
@@ -55,3 +55,46 @@ export const commonValidationSchemas = {
     .transform((val) => (val === '' ? undefined : val))
     .pipe(z.url({ message: '有効なURLを入力してください' }).optional()),
 };
+
+// 会社情報バリデーションスキーマ
+const baseCompanyFields = {
+  companyName: commonValidationSchemas.requiredString('会社名'),
+  businessName: z.string().optional(),
+  logoUrl: commonValidationSchemas.url,
+  address: z.string().optional(),
+  phone: commonValidationSchemas.phoneNumber,
+  contactEmail: z
+    .string()
+    .optional()
+    .transform((val) => (val === '' ? undefined : val))
+    .pipe(
+      z.email({ message: '有効なメールアドレスを入力してください' }).optional()
+    ),
+  invoiceRegistrationNumber: z.string().optional(),
+  representativeName: z.string().optional(),
+  bankName: z.string().optional(),
+  bankBranch: z.string().optional(),
+  bankAccountNumber: z.string().optional(),
+  bankAccountHolder: z.string().optional(),
+};
+
+export const companySchemas = {
+  create: z.object(baseCompanyFields),
+  update: z.object({
+    ...baseCompanyFields,
+    companyName: z.string().min(1, '会社名は必須です').optional(),
+  }),
+};
+
+// API エラーレスポンス共通ユーティリティ
+export const apiErrors = {
+  unauthorized: () => ({ error: '認証が必要です' }),
+  forbidden: () => ({ error: 'アクセス権限がありません' }),
+  notFound: (resource: string) => ({ error: `${resource}が見つかりません` }),
+  conflict: (message: string) => ({ error: message }),
+  validation: (details: z.ZodError['issues']) => ({
+    error: 'バリデーションエラー',
+    details,
+  }),
+  internal: () => ({ error: 'サーバーエラーが発生しました' }),
+};

--- a/lib/shared/forms.ts
+++ b/lib/shared/forms.ts
@@ -16,6 +16,15 @@ export const commonValidationSchemas = {
     .min(1, 'メールアドレスは必須項目です')
     .pipe(z.email({ message: '有効なメールアドレスを入力してください' })),
 
+  // メールアドレス（オプショナル、空文字許可）
+  optionalEmail: z
+    .string()
+    .optional()
+    .transform((val) => (val === '' ? undefined : val))
+    .pipe(
+      z.email({ message: '有効なメールアドレスを入力してください' }).optional()
+    ),
+
   // 電話番号（日本の形式）
   phoneNumber: z
     .string()
@@ -63,13 +72,7 @@ const baseCompanyFields = {
   logoUrl: commonValidationSchemas.url,
   address: z.string().optional(),
   phone: commonValidationSchemas.phoneNumber,
-  contactEmail: z
-    .string()
-    .optional()
-    .transform((val) => (val === '' ? undefined : val))
-    .pipe(
-      z.email({ message: '有効なメールアドレスを入力してください' }).optional()
-    ),
+  contactEmail: commonValidationSchemas.optionalEmail,
   invoiceRegistrationNumber: z.string().optional(),
   representativeName: z.string().optional(),
   bankName: z.string().optional(),

--- a/lib/shared/utils/auth.ts
+++ b/lib/shared/utils/auth.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+
+import { apiErrors } from '@/lib/shared/forms';
+
+/**
+ * リソースの所有者チェックを行う共通ヘルパー関数
+ *
+ * @param resource - チェック対象のリソース（userId プロパティを持つ）
+ * @param currentUserId - 現在のユーザーID
+ * @param resourceName - リソース名（エラーメッセージ用）
+ * @returns 権限がない場合はエラーレスポンス、権限がある場合はnull
+ */
+export function checkResourceOwnership<T extends { userId: string }>(
+  resource: T | null,
+  currentUserId: string,
+  resourceName: string
+): NextResponse | null {
+  if (!resource) {
+    return NextResponse.json(apiErrors.notFound(resourceName), { status: 404 });
+  }
+
+  if (resource.userId !== currentUserId) {
+    return NextResponse.json(apiErrors.forbidden(), { status: 403 });
+  }
+
+  return null;
+}


### PR DESCRIPTION
## 概要

- 会社情報の基本的なCRUD操作を提供するAPIエンドポイントを実装
- Zodバリデーションスキーマの共通化によりコードの再利用性を向上
- エラーハンドリングを統一してAPIレスポンスの一貫性を確保

## 背景

- フロントエンドから会社情報の作成・取得・更新・削除操作を行う基盤APIが必要
- 既存のPrismaスキーマでCompanyモデルは定義済みだが、APIエンドポイントが未実装
- 会社情報管理機能のバックエンド基盤として必要

## 実装内容

### APIエンドポイント
- `POST /api/companies` - 会社情報新規作成（重複チェック付き）
- `GET /api/companies` - 会社情報取得（ユーザー別）
- `PUT /api/companies/[id]` - 会社情報更新（権限チェック付き）
- `DELETE /api/companies/[id]` - 会社情報削除（権限チェック付き）

### 技術的特徴
- **認証・認可**: Clerk認証との統合、所有者チェック実装
- **バリデーション**: Zodスキーマの共通化（`lib/shared/forms.ts`）
- **エラーハンドリング**: 統一されたエラーレスポンス形式
- **型安全性**: TypeScript strict mode完全対応

### 品質改善
- Zod v4推奨記法への対応（`z.url()`, `z.email()`使用）
- 冗長なバリデーション記法を`z.union`で簡潔化
- 未使用パラメータの適切な処理（`_request`プレフィックス）
- ZodErrorの型定義修正（`ZodIssue` → `ZodError['issues']`）

## スクリーンショット（UI変更がある場合）

UI変更なし（APIエンドポイントのみ）

## チェックリスト（必須確認事項）

- [x] 関連Issueにリンクされている
- [x] CIが通過している（test / lint / build）
- [x] 本番環境に影響がないことを確認済み
- [x] UI/UX上の重大な変更がある場合、他メンバーと共有済み（UI変更なし）
- [x] テストコードが追加 or テスト不要の理由を明記した（API単体テストは今後のイシューで対応予定）

## 関連Issue / PR

- Close #31

## 補足

### 実装判断の根拠
- **設計パターン**: RESTful API設計に準拠
- **セキュリティ**: 認証必須 + 所有者チェックで二重保護
- **バリデーション**: 既存の`commonValidationSchemas`パターンを踏襲
- **エラーハンドリング**: 将来の国際化対応を考慮した共通化

### 今後の拡張予定
- フロントエンドとの統合（React Hook Form対応）
- API単体テストの追加
- ファイルアップロード機能（会社ロゴ）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 企業情報の新規作成、取得、更新、削除が可能なAPIエンドポイントを追加しました。
  * 企業情報の所有権チェック機能を導入し、不正アクセスを防止します。
* **バグ修正**
  * APIレスポンスのエラーメッセージが統一され、詳細なエラー内容が返されるようになりました。
* **ドキュメント**
  * 入力項目のバリデーションルールが明確化され、エラー時のレスポンス形式が標準化されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->