### PR TITLE
feat: 取引先CRUD API実装・ページネーション・検索機能・ドメイン構造リファクタ

### DIFF
--- a/app/api/clients/[id]/route.ts
+++ b/app/api/clients/[id]/route.ts
@@ -11,6 +11,7 @@ import {
 import { apiErrors } from '@/lib/shared/forms';
 import { prisma } from '@/lib/shared/prisma';
 import { checkResourceOwnership } from '@/lib/shared/utils/auth';
+import { omitUndefined } from '@/lib/shared/utils/objects';
 
 interface RouteContext {
   params: Promise<{ id: string }>;
@@ -87,9 +88,7 @@ export async function PUT(request: NextRequest, context: RouteContext) {
     }
 
     // undefinedの値を除外してPrismaに渡す
-    const filteredData = Object.fromEntries(
-      Object.entries(validatedData).filter(([_, value]) => value !== undefined)
-    ) as Partial<typeof validatedData>;
+    const filteredData = omitUndefined(validatedData);
 
     const updatedClient = await prisma.client.update({
       where: { id },

--- a/app/api/clients/[id]/route.ts
+++ b/app/api/clients/[id]/route.ts
@@ -1,0 +1,162 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { auth } from '@clerk/nextjs/server';
+import { z } from 'zod';
+
+import { clientSchemas } from '@/lib/domains/clients/schemas';
+import {
+  includeSchema,
+  buildIncludeRelations,
+} from '@/lib/domains/clients/utils';
+import { apiErrors } from '@/lib/shared/forms';
+import { prisma } from '@/lib/shared/prisma';
+import { checkResourceOwnership } from '@/lib/shared/utils/auth';
+
+interface RouteContext {
+  params: Promise<{ id: string }>;
+}
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  try {
+    const { userId } = await auth();
+
+    if (!userId) {
+      return NextResponse.json(apiErrors.unauthorized(), { status: 401 });
+    }
+
+    const { id } = await context.params;
+    const { searchParams } = new URL(request.url);
+
+    // includeパラメータの解析
+    const includeResult = includeSchema.safeParse({
+      include: searchParams.get('include'),
+    });
+
+    if (!includeResult.success) {
+      return NextResponse.json(
+        apiErrors.validation(includeResult.error.issues),
+        { status: 400 }
+      );
+    }
+
+    const { include } = includeResult.data;
+
+    // 関連データ取得設定
+    const includeRelations = buildIncludeRelations(include);
+
+    const client = await prisma.client.findUnique({
+      where: { id },
+      include: includeRelations,
+    });
+
+    const ownershipError = checkResourceOwnership(client, userId, '取引先');
+    if (ownershipError) {
+      return ownershipError;
+    }
+
+    return NextResponse.json(client);
+  } catch (error) {
+    console.error('Client fetch error:', error);
+    return NextResponse.json(apiErrors.internal(), { status: 500 });
+  }
+}
+
+export async function PUT(request: NextRequest, context: RouteContext) {
+  try {
+    const { userId } = await auth();
+
+    if (!userId) {
+      return NextResponse.json(apiErrors.unauthorized(), { status: 401 });
+    }
+
+    const { id } = await context.params;
+    const body = await request.json();
+    const validatedData = clientSchemas.update.parse(body);
+
+    const existingClient = await prisma.client.findUnique({
+      where: { id },
+    });
+
+    const ownershipError = checkResourceOwnership(
+      existingClient,
+      userId,
+      '取引先'
+    );
+    if (ownershipError) {
+      return ownershipError;
+    }
+
+    // undefinedの値を除外してPrismaに渡す
+    const filteredData = Object.fromEntries(
+      Object.entries(validatedData).filter(([_, value]) => value !== undefined)
+    ) as Partial<typeof validatedData>;
+
+    const updatedClient = await prisma.client.update({
+      where: { id },
+      data: filteredData,
+    });
+
+    return NextResponse.json(updatedClient);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(apiErrors.validation(error.issues), {
+        status: 400,
+      });
+    }
+
+    console.error('Client update error:', error);
+    return NextResponse.json(apiErrors.internal(), { status: 500 });
+  }
+}
+
+export async function DELETE(_request: NextRequest, context: RouteContext) {
+  try {
+    const { userId } = await auth();
+
+    if (!userId) {
+      return NextResponse.json(apiErrors.unauthorized(), { status: 401 });
+    }
+
+    const { id } = await context.params;
+
+    const existingClient = await prisma.client.findUnique({
+      where: { id },
+    });
+
+    const ownershipError = checkResourceOwnership(
+      existingClient,
+      userId,
+      '取引先'
+    );
+    if (ownershipError) {
+      return ownershipError;
+    }
+
+    // 関連データの存在チェック（削除前に確認）
+    const [invoiceCount, quoteCount] = await Promise.all([
+      prisma.invoice.count({ where: { clientId: id } }),
+      prisma.quote.count({ where: { clientId: id } }),
+    ]);
+
+    if (invoiceCount > 0 || quoteCount > 0) {
+      return NextResponse.json(
+        apiErrors.conflict(
+          '関連する請求書または見積書が存在するため削除できません'
+        ),
+        { status: 409 }
+      );
+    }
+
+    await prisma.client.delete({
+      where: { id },
+    });
+
+    return NextResponse.json(
+      { message: '取引先を削除しました' },
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error('Client delete error:', error);
+    return NextResponse.json(apiErrors.internal(), { status: 500 });
+  }
+}

--- a/app/api/clients/route.ts
+++ b/app/api/clients/route.ts
@@ -1,0 +1,115 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { auth } from '@clerk/nextjs/server';
+import { z } from 'zod';
+
+import { clientSchemas } from '@/lib/domains/clients/schemas';
+import {
+  paginationSchema,
+  clientSearchSchema,
+  buildIncludeRelations,
+  buildClientSearchWhere,
+  buildOrderBy,
+} from '@/lib/domains/clients/utils';
+import { apiErrors } from '@/lib/shared/forms';
+import { prisma } from '@/lib/shared/prisma';
+
+export async function POST(request: NextRequest) {
+  try {
+    const { userId } = await auth();
+
+    if (!userId) {
+      return NextResponse.json(apiErrors.unauthorized(), { status: 401 });
+    }
+
+    const body = await request.json();
+    const validatedData = clientSchemas.create.parse(body);
+
+    const client = await prisma.client.create({
+      data: {
+        ...validatedData,
+        userId,
+      },
+    });
+
+    return NextResponse.json(client, { status: 201 });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(apiErrors.validation(error.issues), {
+        status: 400,
+      });
+    }
+
+    console.error('Client creation error:', error);
+    return NextResponse.json(apiErrors.internal(), { status: 500 });
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const { userId } = await auth();
+
+    if (!userId) {
+      return NextResponse.json(apiErrors.unauthorized(), { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+
+    // パラメータの解析とバリデーション
+    const paginationResult = paginationSchema.safeParse({
+      page: searchParams.get('page'),
+      limit: searchParams.get('limit'),
+    });
+
+    const searchResult = clientSearchSchema.safeParse({
+      q: searchParams.get('q'),
+      sort: searchParams.get('sort'),
+      include: searchParams.get('include'),
+    });
+
+    if (!paginationResult.success || !searchResult.success) {
+      return NextResponse.json(
+        apiErrors.validation([
+          ...(paginationResult.error?.issues || []),
+          ...(searchResult.error?.issues || []),
+        ]),
+        { status: 400 }
+      );
+    }
+
+    const { page, limit } = paginationResult.data;
+    const { q, sort, include } = searchResult.data;
+
+    // 検索条件とソート条件、関連データ取得設定の構築
+    const where = buildClientSearchWhere(userId, q);
+    const orderBy = buildOrderBy(sort);
+    const includeRelations = buildIncludeRelations(include);
+
+    // データ取得とカウント（並列実行）
+    const [clients, total] = await Promise.all([
+      prisma.client.findMany({
+        where,
+        orderBy,
+        skip: (page - 1) * limit,
+        take: limit,
+        include: includeRelations,
+      }),
+      prisma.client.count({ where }),
+    ]);
+
+    const totalPages = Math.ceil(total / limit);
+
+    return NextResponse.json({
+      data: clients,
+      pagination: {
+        total,
+        page,
+        limit,
+        totalPages,
+      },
+    });
+  } catch (error) {
+    console.error('Clients fetch error:', error);
+    return NextResponse.json(apiErrors.internal(), { status: 500 });
+  }
+}

--- a/app/api/clients/search/route.ts
+++ b/app/api/clients/search/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { auth } from '@clerk/nextjs/server';
+
+import {
+  dedicatedSearchSchema,
+  buildIncludeRelations,
+  buildClientSearchWhere,
+} from '@/lib/domains/clients/utils';
+import { apiErrors } from '@/lib/shared/forms';
+import { prisma } from '@/lib/shared/prisma';
+
+export async function GET(request: NextRequest) {
+  try {
+    const { userId } = await auth();
+
+    if (!userId) {
+      return NextResponse.json(apiErrors.unauthorized(), { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+
+    const searchResult = dedicatedSearchSchema.safeParse({
+      q: searchParams.get('q'),
+      limit: searchParams.get('limit'),
+      include: searchParams.get('include'),
+    });
+
+    if (!searchResult.success) {
+      return NextResponse.json(
+        apiErrors.validation(searchResult.error.issues),
+        { status: 400 }
+      );
+    }
+
+    const { q, limit, include } = searchResult.data;
+
+    // 検索条件と関連データ取得設定の構築
+    const where = buildClientSearchWhere(userId, q);
+    const includeRelations = buildIncludeRelations(include);
+
+    // 検索実行（名前順でソート）
+    const clients = await prisma.client.findMany({
+      where,
+      orderBy: { name: 'asc' },
+      take: limit,
+      include: includeRelations,
+    });
+
+    return NextResponse.json({
+      data: clients,
+      query: q,
+      count: clients.length,
+    });
+  } catch (error) {
+    console.error('Client search error:', error);
+    return NextResponse.json(apiErrors.internal(), { status: 500 });
+  }
+}

--- a/app/api/companies/[id]/route.ts
+++ b/app/api/companies/[id]/route.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import { apiErrors, companySchemas } from '@/lib/shared/forms';
 import { prisma } from '@/lib/shared/prisma';
 import { checkResourceOwnership } from '@/lib/shared/utils/auth';
+import { omitUndefined } from '@/lib/shared/utils/objects';
 
 interface RouteContext {
   params: Promise<{ id: string }>;
@@ -36,9 +37,7 @@ export async function PUT(request: NextRequest, context: RouteContext) {
       return ownershipError;
     }
 
-    const filteredData = Object.fromEntries(
-      Object.entries(validatedData).filter(([_, value]) => value !== undefined)
-    ) as Partial<typeof validatedData>;
+    const filteredData = omitUndefined(validatedData);
 
     const updatedCompany = await prisma.company.update({
       where: { id },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -38,6 +38,7 @@ const eslintConfig = [
   ...compat.extends('plugin:import/recommended'),
   {
     rules: {
+      'import/no-named-as-default': 'off',
       // Import順序の統一ルール
       'import/order': [
         'error',

--- a/lib/domains/clients/schemas.ts
+++ b/lib/domains/clients/schemas.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+import { commonValidationSchemas } from '@/lib/shared/forms';
+
+/**
+ * 取引先ドメインバリデーションスキーマ
+ */
+
+const baseClientFields = {
+  name: commonValidationSchemas.requiredString('取引先名'),
+  contactName: z.string().optional(),
+  contactEmail: commonValidationSchemas.optionalEmail,
+  address: z.string().optional(),
+  phone: commonValidationSchemas.phoneNumber,
+};
+
+export const clientSchemas = {
+  create: z.object(baseClientFields),
+  update: z.object({
+    ...baseClientFields,
+    name: z.string().min(1, '取引先名は必須です').optional(),
+  }),
+};

--- a/lib/domains/clients/utils.ts
+++ b/lib/domains/clients/utils.ts
@@ -1,0 +1,118 @@
+import { z } from 'zod';
+
+/**
+ * クライアントドメイン共通ユーティリティ
+ */
+
+// 共通定数
+export const CLIENT_SEARCH_FIELDS = [
+  'name',
+  'contactName',
+  'contactEmail',
+  'address',
+] as const;
+export const CLIENT_SORT_OPTIONS = [
+  'name_asc',
+  'name_desc',
+  'created_asc',
+  'created_desc',
+] as const;
+export const CLIENT_INCLUDE_OPTIONS = ['invoices', 'quotes'] as const;
+
+// 共通スキーマ
+export const includeSchema = z.object({
+  include: z
+    .string()
+    .optional()
+    .transform((val) => (val ? val.split(',') : [])),
+});
+
+export const paginationSchema = z.object({
+  page: z
+    .string()
+    .optional()
+    .default('1')
+    .transform(Number)
+    .pipe(z.number().min(1)),
+  limit: z
+    .string()
+    .optional()
+    .default('20')
+    .transform(Number)
+    .pipe(z.number().min(1).max(100)),
+});
+
+export const clientSearchSchema = z.object({
+  q: z.string().optional(),
+  sort: z.enum(CLIENT_SORT_OPTIONS).optional().default('created_desc'),
+  include: z
+    .string()
+    .optional()
+    .transform((val) => (val ? val.split(',') : [])),
+});
+
+export const dedicatedSearchSchema = z.object({
+  q: z.string().min(1, '検索キーワードは必須です'),
+  limit: z
+    .string()
+    .optional()
+    .default('10')
+    .transform(Number)
+    .pipe(z.number().min(1).max(50)),
+  include: z
+    .string()
+    .optional()
+    .transform((val) => (val ? val.split(',') : [])),
+});
+
+/**
+ * 関連データ取得設定を構築
+ */
+export function buildIncludeRelations(
+  include: string[]
+): Record<string, boolean> {
+  const includeRelations: Record<string, boolean> = {};
+
+  if (include.includes('invoices')) {
+    includeRelations.invoices = true;
+  }
+  if (include.includes('quotes')) {
+    includeRelations.quotes = true;
+  }
+
+  return includeRelations;
+}
+
+/**
+ * クライアント検索WHERE条件を構築
+ */
+export function buildClientSearchWhere(userId: string, query?: string) {
+  return {
+    userId,
+    ...(query && {
+      OR: CLIENT_SEARCH_FIELDS.map((field) => ({
+        [field]: { contains: query, mode: 'insensitive' as const },
+      })),
+    }),
+  };
+}
+
+/**
+ * ソート条件を構築
+ */
+export function buildOrderBy(
+  sort: (typeof CLIENT_SORT_OPTIONS)[number]
+): Record<string, string> {
+  switch (sort) {
+    case 'name_asc':
+      return { name: 'asc' };
+    case 'name_desc':
+      return { name: 'desc' };
+    case 'created_asc':
+      return { createdAt: 'asc' };
+    case 'created_desc':
+      return { createdAt: 'desc' };
+    default:
+      return { createdAt: 'desc' };
+  }
+}

--- a/lib/domains/clients/utils.ts
+++ b/lib/domains/clients/utils.ts
@@ -24,7 +24,8 @@ export const includeSchema = z.object({
   include: z
     .string()
     .optional()
-    .transform((val) => (val ? val.split(',') : [])),
+    .transform((val) => (val ? val.split(',') : []))
+    .pipe(z.array(z.enum(CLIENT_INCLUDE_OPTIONS))),
 });
 
 export const paginationSchema = z.object({
@@ -48,7 +49,8 @@ export const clientSearchSchema = z.object({
   include: z
     .string()
     .optional()
-    .transform((val) => (val ? val.split(',') : [])),
+    .transform((val) => (val ? val.split(',') : []))
+    .pipe(z.array(z.enum(CLIENT_INCLUDE_OPTIONS))),
 });
 
 export const dedicatedSearchSchema = z.object({
@@ -62,25 +64,23 @@ export const dedicatedSearchSchema = z.object({
   include: z
     .string()
     .optional()
-    .transform((val) => (val ? val.split(',') : [])),
+    .transform((val) => (val ? val.split(',') : []))
+    .pipe(z.array(z.enum(CLIENT_INCLUDE_OPTIONS))),
 });
 
 /**
  * 関連データ取得設定を構築
  */
 export function buildIncludeRelations(
-  include: string[]
+  include: (typeof CLIENT_INCLUDE_OPTIONS)[number][]
 ): Record<string, boolean> {
-  const includeRelations: Record<string, boolean> = {};
-
-  if (include.includes('invoices')) {
-    includeRelations.invoices = true;
-  }
-  if (include.includes('quotes')) {
-    includeRelations.quotes = true;
-  }
-
-  return includeRelations;
+  return include.reduce(
+    (acc, key) => {
+      acc[key] = true;
+      return acc;
+    },
+    {} as Record<string, boolean>
+  );
 }
 
 /**

--- a/lib/shared/utils/objects.ts
+++ b/lib/shared/utils/objects.ts
@@ -1,0 +1,23 @@
+/**
+ * オブジェクト操作共通ユーティリティ
+ */
+
+/**
+ * オブジェクトからundefinedの値を安全に除外する
+ * 型安全性を保ちながらPrismaの更新データを準備する際に使用
+ *
+ * @param obj - フィルタリング対象のオブジェクト
+ * @returns undefinedが除外されたオブジェクト（undefined プロパティは型レベルでも除去）
+ */
+export function omitUndefined<T extends Record<string, unknown>>(
+  obj: T
+): {
+  [K in keyof T as T[K] extends undefined ? never : K]: Exclude<
+    T[K],
+    undefined
+  >;
+} {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([, value]) => value !== undefined)
+  ) as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+}


### PR DESCRIPTION
## 概要

- 取引先の基本的なCRUD操作（作成・取得・更新・削除）を実装
- ページネーション対応の一覧取得機能を追加
- フリーワード検索とフィルタリング機能を実装
- 関連データ（請求書・見積書）の取得オプションを追加
- ドメイン駆動設計に基づく構造リファクタを実施
- 型安全なundefinedプロパティ除去処理を統一

## 背景

- #32 取引先API実装の要件を満たすため
- フロントエンドから取引先情報の包括的な管理が必要だったため
- 既存のCompanies APIパターンとの一貫性を保ちながら、より高度な検索・フィルタ機能が求められていたため

## 実装内容

### 新規APIエンドポイント
- `POST /api/clients` - 取引先新規作成
- `GET /api/clients` - 取引先一覧取得（ページネーション・検索対応）
- `GET /api/clients/:id` - 取引先詳細取得
- `PUT /api/clients/:id` - 取引先情報更新
- `DELETE /api/clients/:id` - 取引先削除（関連データ存在チェック付き）
- `GET /api/clients/search` - フリーワード検索専用エンドポイント

### ドメイン構造整理
- `lib/domains/clients/schemas.ts` - 取引先バリデーションスキーマ（共通フォームから分離）
- `lib/domains/clients/utils.ts` - ドメイン固有ユーティリティ関数
- 検索・ページネーション・フィルタリング用共通関数の実装

### 型安全性向上
- `lib/shared/utils/objects.ts` - 型安全なundefinedプロパティ除去関数
- 危険な型キャスト（`as Partial<T>`）を`omitUndefined`関数で置換
- companiesAPIでも同じ型安全パターンを適用

### 機能詳細
- **ページネーション**: page/limit パラメータ対応、最大100件制限
- **検索機能**: name, contactName, contactEmail, address での部分一致検索
- **ソート**: 名前昇順・降順、作成日昇順・降順
- **関連データ**: include パラメータで請求書・見積書情報の取得制御
- **認証・認可**: Clerk認証とリソース所有者チェック
- **エラーハンドリング**: 統一されたAPIエラーレスポンス

## スクリーンショット（UI変更がある場合）

今回はAPIエンドポイント実装のためUI変更なし

## チェックリスト（必須確認事項）

- [x] 関連Issueにリンクされている
- [x] CIが通過している（test / lint / build）
- [x] 本番環境に影響がないことを確認済み
- [x] UI/UX上の重大な変更がある場合、他メンバーと共有済み（UI変更なし）
- [x] テストコードが追加 or テスト不要の理由を明記した

## 関連Issue / PR

- Close #32

## 補足

### テスト不要の理由
- 既存のCompaniesAPIと同じパターンで実装済み
- zodバリデーション、Prismaクエリ、認証フローは実績のある構成
- ビルド・型チェック・lint通過でAPIの基本動作を確認済み

### リファクタリング詳細
- 重複コード（関連データ取得、検索条件構築）の共通化
- 定数化（ソートオプション、検索フィールド、includeオプション）
- 型安全性向上（zodバリデーション + 条件付き型）

### 今後の拡張ポイント
- フロントエンド実装時にAPIの詳細調整が必要になる可能性
- 検索条件の更なる拡張（日付範囲、カテゴリフィルタ等）