### PR TITLE
feat: 取引先登録フォーム実装・ダッシュボード統合

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,5 +54,8 @@ CLAUDE.md
 # gemini
 GEMINI.md
 
+# serena
+.serena/
+
 # memo
 .memo/

--- a/app/api/clients/route.ts
+++ b/app/api/clients/route.ts
@@ -11,10 +11,10 @@ import {
 import { apiErrors } from '@/lib/shared/forms';
 import { prisma } from '@/lib/shared/prisma';
 import { requireAuth } from '@/lib/shared/utils/auth';
-import { createResource } from '@/lib/shared/utils/crud';
+import { createResourceWithAutoUser } from '@/lib/shared/utils/crud';
 
 export async function POST(request: NextRequest) {
-  return createResource(request, {
+  return createResourceWithAutoUser(request, {
     model: prisma.client,
     schemas: clientSchemas,
     resourceName: '取引先',

--- a/app/dashboard/clients/new/page.tsx
+++ b/app/dashboard/clients/new/page.tsx
@@ -1,0 +1,12 @@
+import { Metadata } from 'next';
+
+import { ClientForm } from '@/components/domains/clients';
+
+export const metadata: Metadata = {
+  title: '新規取引先登録 | SendBill',
+  description: '新しい取引先を登録します',
+};
+
+export default function NewClientPage() {
+  return <ClientForm />;
+}

--- a/app/dashboard/clients/new/page.tsx
+++ b/app/dashboard/clients/new/page.tsx
@@ -9,9 +9,11 @@ export const metadata: Metadata = {
 
 export default function NewClientPage() {
   return (
-    <>
-      <h1 className="text-2xl font-semibold mb-6">新規取引先登録</h1>
-      <ClientForm />
-    </>
+    <main className="min-h-screen bg-gray-50 py-12">
+      <div className="max-w-2xl mx-auto">
+        <h1 className="sr-only">新規取引先登録</h1>
+        <ClientForm />
+      </div>
+    </main>
   );
 }

--- a/app/dashboard/clients/new/page.tsx
+++ b/app/dashboard/clients/new/page.tsx
@@ -8,5 +8,10 @@ export const metadata: Metadata = {
 };
 
 export default function NewClientPage() {
-  return <ClientForm />;
+  return (
+    <>
+      <h1 className="text-2xl font-semibold mb-6">新規取引先登録</h1>
+      <ClientForm />
+    </>
+  );
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -50,9 +50,12 @@ export default async function DashboardPage() {
               <p className="text-gray-600 mb-4">
                 請求先となる取引先の情報を管理します
               </p>
-              <button className="inline-flex items-center px-4 py-2 bg-gray-300 text-gray-600 text-sm font-medium rounded-md cursor-not-allowed">
-                準備中
-              </button>
+              <Link
+                href="/dashboard/clients/new"
+                className="inline-flex items-center px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-md hover:bg-blue-700 transition-colors"
+              >
+                新規登録
+              </Link>
             </div>
 
             {/* 請求書管理カード */}

--- a/components/domains/clients/ClientForm.tsx
+++ b/components/domains/clients/ClientForm.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import React from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Spinner } from '@/components/ui/spinner';
+import { useClientForm } from '@/lib/domains/clients/hooks';
+
+import { ClientFormFields } from './ClientFormFields';
+
+export function ClientForm() {
+  const { form, state, actions } = useClientForm();
+
+  const {
+    control,
+    handleSubmit,
+    formState: { errors, isValid, isDirty },
+  } = form;
+
+  const { isSubmitting, submitError, submitSuccess } = state;
+  const { onSubmit, onReset } = actions;
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-12">
+      <div className="max-w-2xl mx-auto">
+        <Card className="p-6">
+          <div className="mb-6">
+            <h1 className="text-2xl font-bold text-gray-900">取引先登録</h1>
+            <p className="text-gray-600 mt-2">
+              新しい取引先の情報を登録してください
+            </p>
+          </div>
+
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+            <ClientFormFields
+              control={control}
+              errors={errors}
+              isSubmitting={isSubmitting}
+            />
+
+            {/* 送信結果メッセージ */}
+            {submitSuccess && (
+              <div className="p-4 bg-green-50 border border-green-200 rounded-md animate-in fade-in-0 slide-in-from-top-2">
+                <p className="text-green-800 text-sm font-medium">
+                  ✓
+                  取引先が正常に登録されました！3秒後にダッシュボードに戻ります...
+                </p>
+              </div>
+            )}
+
+            {submitError && (
+              <div className="p-4 bg-red-50 border border-red-200 rounded-md animate-in fade-in-0 slide-in-from-top-2">
+                <p className="text-red-800 text-sm font-medium">
+                  ✗ {submitError}
+                </p>
+              </div>
+            )}
+
+            {/* アクション */}
+            <div className="flex justify-end gap-3 pt-4">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={onReset}
+                disabled={isSubmitting}
+              >
+                リセット
+              </Button>
+              <Button
+                type="submit"
+                disabled={isSubmitting || !isValid}
+                className={isSubmitting ? 'cursor-wait' : ''}
+              >
+                {isSubmitting && (
+                  <Spinner size="sm" color="white" className="mr-2" />
+                )}
+                {isSubmitting ? '登録中...' : '登録'}
+              </Button>
+            </div>
+          </form>
+
+          {/* フォーム状態表示（開発用） */}
+          {process.env.NODE_ENV === 'development' && (
+            <div className="mt-6 p-4 bg-gray-100 rounded">
+              <h3 className="font-semibold text-sm text-gray-700 mb-2">
+                フォーム状態
+              </h3>
+              <ul className="text-xs text-gray-600 space-y-1">
+                <li>有効: {isValid ? 'はい' : 'いいえ'}</li>
+                <li>変更済み: {isDirty ? 'はい' : 'いいえ'}</li>
+                <li>送信中: {isSubmitting ? 'はい' : 'いいえ'}</li>
+              </ul>
+            </div>
+          )}
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/components/domains/clients/ClientForm.tsx
+++ b/components/domains/clients/ClientForm.tsx
@@ -14,7 +14,6 @@ export function ClientForm() {
 
   const {
     control,
-    handleSubmit,
     formState: { errors, isValid, isDirty },
   } = form;
 
@@ -32,7 +31,7 @@ export function ClientForm() {
             </p>
           </div>
 
-          <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+          <form onSubmit={onSubmit} className="space-y-6">
             <ClientFormFields
               control={control}
               errors={errors}
@@ -69,7 +68,7 @@ export function ClientForm() {
               </Button>
               <Button
                 type="submit"
-                disabled={isSubmitting || !isValid}
+                disabled={isSubmitting}
                 className={isSubmitting ? 'cursor-wait' : ''}
               >
                 {isSubmitting && (

--- a/components/domains/clients/ClientFormFields.tsx
+++ b/components/domains/clients/ClientFormFields.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import React from 'react';
+
+import { Controller } from 'react-hook-form';
+
+import { FormFieldWrapper } from '@/components/ui/form-field';
+import { Input } from '@/components/ui/input';
+import { ClientFormData } from '@/lib/domains/clients/types';
+
+import type { Control, FieldErrors } from 'react-hook-form';
+interface ClientFormFieldsProps {
+  control: Control<ClientFormData>;
+  errors: FieldErrors<ClientFormData>;
+  isSubmitting: boolean;
+}
+
+export function ClientFormFields({
+  control,
+  errors,
+  isSubmitting,
+}: ClientFormFieldsProps) {
+  return (
+    <div className="space-y-6">
+      {/* 基本情報 */}
+      <div className="space-y-4">
+        <h3 className="text-lg font-semibold text-gray-900">基本情報</h3>
+
+        {/* 取引先名（必須） */}
+        <Controller
+          control={control}
+          name="name"
+          render={({ field }) => (
+            <FormFieldWrapper
+              label="取引先名"
+              id="name"
+              required
+              error={errors.name?.message}
+            >
+              <Input
+                {...field}
+                id="name"
+                placeholder="株式会社サンプル"
+                disabled={isSubmitting}
+              />
+            </FormFieldWrapper>
+          )}
+        />
+      </div>
+
+      {/* 担当者情報（任意） */}
+      <div className="space-y-4">
+        <h3 className="text-lg font-semibold text-gray-900">
+          担当者情報（任意）
+        </h3>
+
+        {/* 担当者名 */}
+        <Controller
+          control={control}
+          name="contactName"
+          render={({ field }) => (
+            <FormFieldWrapper
+              label="担当者名"
+              id="contactName"
+              error={errors.contactName?.message}
+            >
+              <Input
+                {...field}
+                id="contactName"
+                placeholder="田中太郎"
+                disabled={isSubmitting}
+              />
+            </FormFieldWrapper>
+          )}
+        />
+
+        {/* 担当者メールアドレス */}
+        <Controller
+          control={control}
+          name="contactEmail"
+          render={({ field }) => (
+            <FormFieldWrapper
+              label="担当者メールアドレス"
+              id="contactEmail"
+              error={errors.contactEmail?.message}
+            >
+              <Input
+                {...field}
+                id="contactEmail"
+                type="email"
+                placeholder="tanaka@example.com"
+                disabled={isSubmitting}
+              />
+            </FormFieldWrapper>
+          )}
+        />
+      </div>
+
+      {/* 連絡先情報（任意） */}
+      <div className="space-y-4">
+        <h3 className="text-lg font-semibold text-gray-900">
+          連絡先情報（任意）
+        </h3>
+
+        {/* 住所 */}
+        <Controller
+          control={control}
+          name="address"
+          render={({ field }) => (
+            <FormFieldWrapper
+              label="住所"
+              id="address"
+              error={errors.address?.message}
+            >
+              <Input
+                {...field}
+                id="address"
+                placeholder="東京都渋谷区..."
+                disabled={isSubmitting}
+              />
+            </FormFieldWrapper>
+          )}
+        />
+
+        {/* 電話番号 */}
+        <Controller
+          control={control}
+          name="phone"
+          render={({ field }) => (
+            <FormFieldWrapper
+              label="電話番号"
+              id="phone"
+              error={errors.phone?.message}
+              description="ハイフンありまたはなしで入力してください"
+            >
+              <Input
+                {...field}
+                id="phone"
+                placeholder="03-1234-5678"
+                disabled={isSubmitting}
+              />
+            </FormFieldWrapper>
+          )}
+        />
+      </div>
+    </div>
+  );
+}

--- a/components/domains/clients/index.ts
+++ b/components/domains/clients/index.ts
@@ -1,0 +1,2 @@
+export { ClientForm } from './ClientForm';
+export { ClientFormFields } from './ClientFormFields';

--- a/lib/domains/clients/hooks.ts
+++ b/lib/domains/clients/hooks.ts
@@ -1,0 +1,96 @@
+import { useState } from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+
+import { clientSchemas } from './schemas';
+import { ClientFormData, UseClientFormReturn } from './types';
+
+/**
+ * 取引先フォーム管理フック
+ */
+export function useClientForm(): UseClientFormReturn {
+  const router = useRouter();
+  const [submitError, setSubmitError] = useState<string>();
+  const [submitSuccess, setSubmitSuccess] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const form = useForm<ClientFormData>({
+    resolver: zodResolver(clientSchemas.create),
+    defaultValues: {
+      name: '',
+      contactName: '',
+      contactEmail: '',
+      address: '',
+      phone: '',
+    },
+    mode: 'onBlur',
+  });
+
+  const onSubmit = async (data: ClientFormData) => {
+    try {
+      setIsSubmitting(true);
+      setSubmitError(undefined);
+      setSubmitSuccess(false);
+
+      const response = await fetch('/api/clients', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(data),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || '取引先の登録に失敗しました');
+      }
+
+      setSubmitSuccess(true);
+
+      // 3秒後にダッシュボードにリダイレクト
+      setTimeout(() => {
+        router.push('/dashboard');
+      }, 3000);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : '取引先の登録に失敗しました';
+      setSubmitError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const onReset = () => {
+    form.reset({
+      name: '',
+      contactName: '',
+      contactEmail: '',
+      address: '',
+      phone: '',
+    });
+    setSubmitError(undefined);
+    setSubmitSuccess(false);
+  };
+
+  const clearMessages = () => {
+    setSubmitError(undefined);
+    setSubmitSuccess(false);
+  };
+
+  return {
+    form,
+    state: {
+      isSubmitting,
+      submitError,
+      submitSuccess,
+    },
+    actions: {
+      onSubmit,
+      onReset,
+      clearMessages,
+    },
+  };
+}

--- a/lib/domains/clients/types.ts
+++ b/lib/domains/clients/types.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import { clientSchemas } from './schemas';
 
+import type { UseFormReturn } from 'react-hook-form';
 /**
  * 取引先ドメイン型定義
  */
@@ -18,14 +19,14 @@ export interface ClientFormState {
 
 // フォーム操作
 export interface ClientFormActions {
-  onSubmit: (data: ClientFormData) => Promise<void>;
+  onSubmit: (e?: React.BaseSyntheticEvent) => Promise<void>;
   onReset: () => void;
   clearMessages: () => void;
 }
 
 // useClientForm フックの戻り値型
 export interface UseClientFormReturn {
-  form: ReturnType<typeof import('react-hook-form').useForm<ClientFormData>>;
+  form: UseFormReturn<ClientFormData>;
   state: ClientFormState;
   actions: ClientFormActions;
 }

--- a/lib/domains/clients/types.ts
+++ b/lib/domains/clients/types.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+import { clientSchemas } from './schemas';
+
+/**
+ * 取引先ドメイン型定義
+ */
+
+// 取引先フォームデータ型
+export type ClientFormData = z.infer<typeof clientSchemas.create>;
+
+// フォーム送信状態
+export interface ClientFormState {
+  isSubmitting: boolean;
+  submitError?: string;
+  submitSuccess: boolean;
+}
+
+// フォーム操作
+export interface ClientFormActions {
+  onSubmit: (data: ClientFormData) => Promise<void>;
+  onReset: () => void;
+  clearMessages: () => void;
+}
+
+// useClientForm フックの戻り値型
+export interface UseClientFormReturn {
+  form: ReturnType<typeof import('react-hook-form').useForm<ClientFormData>>;
+  state: ClientFormState;
+  actions: ClientFormActions;
+}

--- a/lib/domains/clients/utils.ts
+++ b/lib/domains/clients/utils.ts
@@ -112,3 +112,31 @@ export function buildOrderBy(
 ): Record<string, string> {
   return SORT_MAPPING[sort] ?? { createdAt: 'desc' };
 }
+
+/**
+ * フォームデータの前処理（空文字をundefinedに変換）
+ */
+export function preprocessClientFormData(data: Record<string, unknown>) {
+  const processed = { ...data };
+
+  // 空文字列をundefinedに変換（オプショナルフィールド用）
+  Object.keys(processed).forEach((key) => {
+    if (processed[key] === '') {
+      processed[key] = undefined;
+    }
+  });
+
+  return processed;
+}
+
+/**
+ * フォーム送信時のエラーメッセージを生成
+ */
+export function generateClientFormErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    // API エラーメッセージをそのまま使用
+    return error.message;
+  }
+
+  return '取引先の登録中にエラーが発生しました';
+}


### PR DESCRIPTION
## 概要

- 取引先登録フォームの完全実装
- React Hook FormとZodによるバリデーション機能
- ダッシュボードからの導線設計とUI統合

## 背景

- 取引先管理機能の基盤として新規登録フォームが必要
- ユーザーがダッシュボードから直接アクセスできる導線の整備
- フォーム状態管理とエラーハンドリングの品質向上

## 実装内容

- `/dashboard/clients/new` ページの新規作成
- `useClientForm` カスタムフックによる状態管理
- Zodスキーマを使用した型安全なバリデーション
- React Hook Formとの統合による効率的なフォーム制御
- 成功・エラー状態の適切なUI表示
- ダッシュボードの取引先管理カードに新規登録リンク追加
- Geminiレビューに基づく3つの改善:
  - フォーム状態管理のreact-hook-formへの統一
  - setTimeoutメモリリーク対策（useEffectによる自動クリーンアップ）
  - APIエラーハンドリング強化（非JSONレスポンス対応）

## チェックリスト（必須確認事項）

- [x] 関連Issueにリンクされている
- [x] CIが通過している（test / lint / build）
- [x] 本番環境に影響がないことを確認済み
- [x] UI/UX上の重大な変更がある場合、他メンバーと共有済み
- [x] テストコードが追加 or テスト不要の理由を明記した

## 関連Issue / PR

- Close #38

## 補足

- フォーム送信後は3秒後に自動でダッシュボードにリダイレクト
- TypeScript strict mode完全対応
- 全ての品質チェック（TypeScript、ESLint、ビルド、テスト）が通過済み