### PR TITLE
feat: 見積書作成フォーム・取引先選択・自動採番実装

### DIFF
--- a/app/dashboard/quotes/new/page.tsx
+++ b/app/dashboard/quotes/new/page.tsx
@@ -1,0 +1,19 @@
+import { Metadata } from 'next';
+
+import { QuoteForm } from '@/components/domains/quotes/QuoteForm';
+
+export const metadata: Metadata = {
+  title: '新規見積書作成 | SendBill',
+  description: '新しい見積書を作成します',
+};
+
+export default function NewQuotePage() {
+  return (
+    <main className="min-h-screen bg-gray-50 py-12">
+      <div className="max-w-2xl mx-auto">
+        <h1 className="sr-only">新規見積書作成</h1>
+        <QuoteForm />
+      </div>
+    </main>
+  );
+}

--- a/components/domains/quotes/ClientSelector.tsx
+++ b/components/domains/quotes/ClientSelector.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import { ChevronDown, Plus } from 'lucide-react';
+
+export interface Client {
+  id: string;
+  name: string;
+  contactName?: string;
+}
+
+export interface ClientSelectorProps {
+  value?: string;
+  onChange: (clientId: string) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  id?: string;
+}
+
+export function ClientSelector({
+  value,
+  onChange,
+  disabled = false,
+  placeholder = '取引先を選択',
+  id,
+}: ClientSelectorProps) {
+  const [clients, setClients] = useState<Client[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>();
+  const [isOpen, setIsOpen] = useState(false);
+  const router = useRouter();
+
+  // 取引先一覧を取得
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchClients = async () => {
+      try {
+        setLoading(true);
+        setError(undefined);
+
+        // デフォルトのクエリパラメータでAPI呼び出し
+        const params = new URLSearchParams({
+          page: '1',
+          limit: '100', // セレクター用なので多めに取得
+          sort: 'name_asc',
+        });
+        const response = await fetch(`/api/clients?${params}`);
+
+        if (!response.ok) {
+          throw new Error('取引先の取得に失敗しました');
+        }
+
+        const data = await response.json();
+        if (isMounted) {
+          setClients(data.data || []);
+        }
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : '取引先の取得に失敗しました';
+        if (isMounted) {
+          setError(message);
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void fetchClients();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const selectedClient = clients.find((client) => client.id === value);
+
+  const handleClientSelect = (clientId: string) => {
+    onChange(clientId);
+    setIsOpen(false);
+  };
+
+  const handleNewClient = () => {
+    router.push('/dashboard/clients/new');
+  };
+
+  if (loading) {
+    return (
+      <div className="w-full px-3 py-2 border border-gray-300 rounded-md bg-gray-50 text-gray-500">
+        取引先を読み込み中...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="w-full px-3 py-2 border border-red-300 rounded-md bg-red-50 text-red-700">
+        {error}
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        id={id}
+        onClick={() => !disabled && setIsOpen(!isOpen)}
+        disabled={disabled}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        aria-label="取引先を選択"
+        className="w-full flex items-center justify-between px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-50 disabled:text-gray-500"
+      >
+        <span className="block truncate">
+          {selectedClient ? (
+            <span>
+              {selectedClient.name}
+              {selectedClient.contactName && (
+                <span className="text-gray-500 ml-2">
+                  ({selectedClient.contactName})
+                </span>
+              )}
+            </span>
+          ) : (
+            <span className="text-gray-500">{placeholder}</span>
+          )}
+        </span>
+        <ChevronDown
+          className={`w-5 h-5 text-gray-400 transition-transform ${
+            isOpen ? 'rotate-180' : ''
+          }`}
+        />
+      </button>
+
+      {isOpen && (
+        <div
+          className="absolute z-50 mt-1 w-full bg-white shadow-lg max-h-60 rounded-md py-1 text-base ring-1 ring-black ring-opacity-5 overflow-auto focus:outline-none"
+          role="listbox"
+          aria-label="取引先一覧"
+        >
+          {clients.length === 0 ? (
+            <div className="px-3 py-2 text-gray-500 text-sm">
+              取引先が登録されていません
+            </div>
+          ) : (
+            clients.map((client) => (
+              <button
+                key={client.id}
+                type="button"
+                onClick={() => handleClientSelect(client.id)}
+                role="option"
+                aria-selected={client.id === value}
+                className={`w-full text-left px-3 py-2 hover:bg-gray-100 focus:bg-gray-100 focus:outline-none ${
+                  client.id === value ? 'bg-blue-50 text-blue-600' : ''
+                }`}
+              >
+                <div className="block truncate">
+                  {client.name}
+                  {client.contactName && (
+                    <span className="text-gray-500 ml-2">
+                      ({client.contactName})
+                    </span>
+                  )}
+                </div>
+              </button>
+            ))
+          )}
+
+          {/* 新規取引先作成ボタン */}
+          <div className="border-t border-gray-200 mt-1">
+            <button
+              type="button"
+              onClick={handleNewClient}
+              className="w-full text-left px-3 py-2 text-blue-600 hover:bg-blue-50 focus:bg-blue-50 focus:outline-none flex items-center"
+            >
+              <Plus className="w-4 h-4 mr-2" />
+              新しい取引先を作成
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* オーバーレイ（ドロップダウンを閉じるため） */}
+      {isOpen && (
+        <div className="fixed inset-0 z-40" onClick={() => setIsOpen(false)} />
+      )}
+    </div>
+  );
+}

--- a/components/domains/quotes/QuoteBasicInfoFields.tsx
+++ b/components/domains/quotes/QuoteBasicInfoFields.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import type { ChangeEvent } from 'react';
+
+import {
+  Controller,
+  type Control,
+  type FieldErrors,
+  type FieldPath,
+} from 'react-hook-form';
+
+import { FormFieldWrapper } from '@/components/ui/form-field';
+import { Input } from '@/components/ui/input';
+import { toDateInputValue, fromDateInputValue } from '@/lib/shared/utils/date';
+
+import { ClientSelector } from './ClientSelector';
+
+import type { QuoteBasicsShape } from './types';
+
+export interface QuoteBasicInfoFieldsProps<T extends QuoteBasicsShape> {
+  control: Control<T>;
+  errors: FieldErrors<T>;
+  isSubmitting: boolean;
+}
+
+export function QuoteBasicInfoFields<T extends QuoteBasicsShape>({
+  control,
+  errors,
+  isSubmitting,
+}: QuoteBasicInfoFieldsProps<T>) {
+  const toErrorMessage = (m: unknown): string | undefined =>
+    typeof m === 'string' ? m : undefined;
+  const toDateChange =
+    (onChange: (value: unknown) => void) =>
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const date = fromDateInputValue(e.target.value);
+      onChange(date);
+    };
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold text-gray-900">基本情報</h3>
+
+      {/* 取引先選択（必須） */}
+      <Controller
+        control={control}
+        name={'clientId' as FieldPath<T>}
+        render={({ field }) => (
+          <FormFieldWrapper
+            label="取引先"
+            id="clientId"
+            required
+            error={toErrorMessage(errors.clientId?.message)}
+          >
+            <ClientSelector
+              id="clientId"
+              value={typeof field.value === 'string' ? field.value : ''}
+              onChange={field.onChange}
+              disabled={isSubmitting}
+              placeholder="取引先を選択してください"
+            />
+          </FormFieldWrapper>
+        )}
+      />
+
+      {/* 発行日（必須） */}
+      <Controller
+        control={control}
+        name={'issueDate' as FieldPath<T>}
+        render={({ field }) => (
+          <FormFieldWrapper
+            label="発行日"
+            id="issueDate"
+            required
+            error={toErrorMessage(errors.issueDate?.message)}
+          >
+            <Input
+              {...field}
+              value={
+                field.value instanceof Date ? toDateInputValue(field.value) : ''
+              }
+              onChange={toDateChange(field.onChange)}
+              id="issueDate"
+              type="date"
+              disabled={isSubmitting}
+            />
+          </FormFieldWrapper>
+        )}
+      />
+
+      {/* 有効期限（任意） */}
+      <Controller
+        control={control}
+        name={'expiryDate' as FieldPath<T>}
+        render={({ field }) => (
+          <FormFieldWrapper
+            label="有効期限"
+            id="expiryDate"
+            error={toErrorMessage(errors.expiryDate?.message)}
+          >
+            <Input
+              {...field}
+              value={
+                field.value instanceof Date ? toDateInputValue(field.value) : ''
+              }
+              onChange={toDateChange(field.onChange)}
+              id="expiryDate"
+              type="date"
+              disabled={isSubmitting}
+              placeholder="有効期限を設定（任意）"
+            />
+          </FormFieldWrapper>
+        )}
+      />
+
+      {/* 備考（任意） */}
+      <Controller
+        control={control}
+        name={'notes' as FieldPath<T>}
+        render={({ field }) => (
+          <FormFieldWrapper
+            label="備考"
+            id="notes"
+            error={toErrorMessage(errors.notes?.message)}
+          >
+            <textarea
+              {...field}
+              value={typeof field.value === 'string' ? field.value : ''}
+              id="notes"
+              placeholder="特記事項があれば記入してください"
+              disabled={isSubmitting}
+              rows={3}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-50 disabled:text-gray-500"
+            />
+          </FormFieldWrapper>
+        )}
+      />
+    </div>
+  );
+}

--- a/components/domains/quotes/QuoteBasicInfoFields.tsx
+++ b/components/domains/quotes/QuoteBasicInfoFields.tsx
@@ -11,11 +11,10 @@ import {
 
 import { FormFieldWrapper } from '@/components/ui/form-field';
 import { Input } from '@/components/ui/input';
+import type { QuoteBasicsShape } from '@/lib/domains/quotes/types';
 import { toDateInputValue, fromDateInputValue } from '@/lib/shared/utils/date';
 
 import { ClientSelector } from './ClientSelector';
-
-import type { QuoteBasicsShape } from './types';
 
 export interface QuoteBasicInfoFieldsProps<T extends QuoteBasicsShape> {
   control: Control<T>;

--- a/components/domains/quotes/QuoteForm.tsx
+++ b/components/domains/quotes/QuoteForm.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { BaseForm } from '@/components/ui/BaseForm';
+import { useQuoteForm } from '@/lib/domains/quotes/hooks';
+
+import { QuoteFormFields } from './QuoteFormFields';
+
+export function QuoteForm() {
+  const { form, state, actions } = useQuoteForm();
+
+  const {
+    control,
+    formState: { errors, isValid, isDirty },
+  } = form;
+
+  const { isSubmitting, submitError } = state;
+  const { onSubmit, onReset } = actions;
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-12">
+      <div className="max-w-2xl mx-auto">
+        <BaseForm
+          title="見積書作成"
+          description="新しい見積書を作成してください"
+          onSubmit={onSubmit}
+          onReset={onReset}
+          isSubmitting={isSubmitting}
+          isValid={isValid}
+          submitError={submitError}
+          submitLabel="作成"
+          submittingLabel="作成中..."
+        >
+          <QuoteFormFields
+            control={control}
+            errors={errors}
+            isSubmitting={isSubmitting}
+          />
+
+          {/* フォーム状態表示（開発用） */}
+          {process.env.NODE_ENV === 'development' && (
+            <div className="mt-6 p-4 bg-gray-100 rounded">
+              <h3 className="font-semibold text-sm text-gray-700 mb-2">
+                フォーム状態
+              </h3>
+              <ul className="text-xs text-gray-600 space-y-1">
+                <li>有効: {isValid ? 'はい' : 'いいえ'}</li>
+                <li>変更済み: {isDirty ? 'はい' : 'いいえ'}</li>
+                <li>送信中: {isSubmitting ? 'はい' : 'いいえ'}</li>
+              </ul>
+            </div>
+          )}
+        </BaseForm>
+      </div>
+    </div>
+  );
+}

--- a/components/domains/quotes/QuoteFormFields.tsx
+++ b/components/domains/quotes/QuoteFormFields.tsx
@@ -3,10 +3,9 @@
 import { type Control, type FieldErrors } from 'react-hook-form';
 
 import type { QuoteFormData } from '@/lib/domains/quotes/schemas';
+import type { QuoteBasicsShape } from '@/lib/domains/quotes/types';
 
 import { QuoteBasicInfoFields } from './QuoteBasicInfoFields';
-
-import type { QuoteBasicsShape } from './types';
 
 export interface QuoteFormFieldsProps<
   T extends QuoteBasicsShape = QuoteFormData,

--- a/components/domains/quotes/QuoteFormFields.tsx
+++ b/components/domains/quotes/QuoteFormFields.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { type Control, type FieldErrors } from 'react-hook-form';
+
+import type { QuoteFormData } from '@/lib/domains/quotes/schemas';
+
+import { QuoteBasicInfoFields } from './QuoteBasicInfoFields';
+
+import type { QuoteBasicsShape } from './types';
+
+export interface QuoteFormFieldsProps<
+  T extends QuoteBasicsShape = QuoteFormData,
+> {
+  control: Control<T>;
+  errors: FieldErrors<T>;
+  isSubmitting: boolean;
+}
+
+export function QuoteFormFields<T extends QuoteBasicsShape = QuoteFormData>({
+  control,
+  errors,
+  isSubmitting,
+}: QuoteFormFieldsProps<T>) {
+  return (
+    <div className="space-y-6">
+      <QuoteBasicInfoFields<T>
+        control={control}
+        errors={errors}
+        isSubmitting={isSubmitting}
+      />
+    </div>
+  );
+}

--- a/components/domains/quotes/index.ts
+++ b/components/domains/quotes/index.ts
@@ -1,0 +1,4 @@
+export { QuoteForm } from './QuoteForm';
+export { QuoteFormFields } from './QuoteFormFields';
+export { QuoteBasicInfoFields } from './QuoteBasicInfoFields';
+export { ClientSelector } from './ClientSelector';

--- a/components/domains/quotes/types.ts
+++ b/components/domains/quotes/types.ts
@@ -1,7 +1,0 @@
-// 最小形：このドメインUIが実際に触るフィールドのみ
-export interface QuoteBasicsShape {
-  clientId: string;
-  issueDate: Date;
-  expiryDate?: Date;
-  notes?: string;
-}

--- a/components/domains/quotes/types.ts
+++ b/components/domains/quotes/types.ts
@@ -1,0 +1,7 @@
+// 最小形：このドメインUIが実際に触るフィールドのみ
+export interface QuoteBasicsShape {
+  clientId: string;
+  issueDate: Date;
+  expiryDate?: Date;
+  notes?: string;
+}

--- a/components/ui/BaseForm.tsx
+++ b/components/ui/BaseForm.tsx
@@ -34,8 +34,6 @@ export function BaseForm({
   isSubmitting,
   isValid = true,
   submitError,
-  submitSuccess = false,
-  successMessage,
   submitLabel = '送信',
   submittingLabel = '送信中...',
   resetLabel = 'リセット',
@@ -68,11 +66,6 @@ export function BaseForm({
         className="space-y-6"
       >
         {children}
-
-        {/* 送信結果メッセージ */}
-        {submitSuccess && successMessage && (
-          <FormStatusMessage type="success" message={successMessage} />
-        )}
 
         {submitError && (
           <FormStatusMessage type="error" message={submitError} />

--- a/lib/domains/quotes/form-schemas.ts
+++ b/lib/domains/quotes/form-schemas.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
 
+// 時刻を無視して「日付のみ」で比較するための正規化
+const normalizeDate = (d: Date) =>
+  new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+
 // UI用フォームスキーマ（RHFのフィールド型と一致させるためにcoerceを使わない）
 export const quoteFormUiSchema = z
   .object({
@@ -14,7 +18,12 @@ export const quoteFormUiSchema = z
       .max(2000, '備考は2000文字以内で入力してください')
       .optional(),
   })
-  .refine((v) => !v.expiryDate || v.expiryDate >= v.issueDate, {
-    path: ['expiryDate'],
-    message: '有効期限は発行日以降を指定してください',
-  });
+  .refine(
+    (v) =>
+      !v.expiryDate ||
+      normalizeDate(v.expiryDate) >= normalizeDate(v.issueDate),
+    {
+      path: ['expiryDate'],
+      message: '有効期限は発行日以降を指定してください',
+    }
+  );

--- a/lib/domains/quotes/form-schemas.ts
+++ b/lib/domains/quotes/form-schemas.ts
@@ -1,9 +1,20 @@
 import { z } from 'zod';
 
 // UI用フォームスキーマ（RHFのフィールド型と一致させるためにcoerceを使わない）
-export const quoteFormUiSchema = z.object({
-  clientId: z.string().min(1, 'クライアントIDは必須です'),
-  issueDate: z.date(),
-  expiryDate: z.date().optional(),
-  notes: z.string().optional(),
-});
+export const quoteFormUiSchema = z
+  .object({
+    // 取引先IDは空白しかない値を拒否
+    clientId: z.string().trim().min(1, '取引先は必須項目です'),
+    issueDate: z.date(),
+    expiryDate: z.date().optional(),
+    // 備考は空白のみを実質未入力扱い＋過度な長文を制限
+    notes: z
+      .string()
+      .trim()
+      .max(2000, '備考は2000文字以内で入力してください')
+      .optional(),
+  })
+  .refine((v) => !v.expiryDate || v.expiryDate >= v.issueDate, {
+    path: ['expiryDate'],
+    message: '有効期限は発行日以降を指定してください',
+  });

--- a/lib/domains/quotes/form-schemas.ts
+++ b/lib/domains/quotes/form-schemas.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+// UI用フォームスキーマ（RHFのフィールド型と一致させるためにcoerceを使わない）
+export const quoteFormUiSchema = z.object({
+  clientId: z.string().min(1, 'クライアントIDは必須です'),
+  issueDate: z.date(),
+  expiryDate: z.date().optional(),
+  notes: z.string().optional(),
+});

--- a/lib/domains/quotes/hooks.ts
+++ b/lib/domains/quotes/hooks.ts
@@ -1,0 +1,227 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm, type UseFormReturn } from 'react-hook-form';
+import { toast } from 'sonner';
+
+import { omitUndefined } from '@/lib/shared/utils/objects';
+
+import { quoteFormUiSchema } from './form-schemas';
+import { type QuoteFormData } from './schemas';
+
+import type { Quote } from './types';
+
+export interface UseQuoteFormOptions {
+  quoteId?: string;
+}
+
+export interface UseQuoteFormState {
+  isSubmitting: boolean;
+  submitError?: string;
+  submitSuccess: boolean;
+  isLoading: boolean;
+  fetchError?: string;
+  quote?: Quote;
+}
+
+export interface UseQuoteFormActions {
+  onSubmit: (e?: React.BaseSyntheticEvent) => Promise<void>;
+  onReset: () => void;
+  clearMessages: () => void;
+}
+
+export interface UseQuoteFormReturn {
+  form: UseFormReturn<QuoteFormData, unknown, QuoteFormData>;
+  state: UseQuoteFormState;
+  actions: UseQuoteFormActions;
+}
+
+export function useQuoteForm(
+  options: UseQuoteFormOptions = {}
+): UseQuoteFormReturn {
+  const { quoteId } = options;
+  const router = useRouter();
+
+  // 基本状態
+  const [submitError, setSubmitError] = useState<string>();
+  const [submitSuccess, setSubmitSuccess] = useState(false);
+
+  // 編集モード用の追加状態
+  const [isLoading, setIsLoading] = useState(!!quoteId);
+  const [fetchError, setFetchError] = useState<string>();
+  const [quote, setQuote] = useState<Quote>();
+
+  // モード判定
+  const isEditMode = !!quoteId;
+
+  // フォームはUI専用スキーマで検証（Dateを要求）
+  const formSchema = quoteFormUiSchema;
+
+  const defaultCreateValues: QuoteFormData = {
+    clientId: '',
+    issueDate: new Date(),
+    expiryDate: undefined,
+    notes: '',
+  };
+
+  const form = useForm<QuoteFormData, unknown, QuoteFormData>({
+    resolver: zodResolver(formSchema),
+    defaultValues: defaultCreateValues,
+    mode: 'onBlur',
+  });
+
+  const toFormValuesFromQuote = (q: Quote): QuoteFormData => ({
+    clientId: q.clientId,
+    issueDate: new Date(q.issueDate),
+    expiryDate: q.expiryDate ? new Date(q.expiryDate) : undefined,
+    notes: q.notes || '',
+  });
+
+  // 編集モード時の初期データ取得
+  useEffect(() => {
+    if (!quoteId) return;
+
+    let isMounted = true;
+
+    const fetchQuote = async () => {
+      try {
+        if (isMounted) {
+          setIsLoading(true);
+          setFetchError(undefined);
+        }
+
+        const response = await fetch(`/api/quotes/${quoteId}`);
+
+        if (!response.ok) {
+          if (response.status === 404) {
+            throw new Error('見積書が見つかりません');
+          }
+          let errorMessage = '見積書の取得に失敗しました';
+          try {
+            const errorData = await response.json();
+            errorMessage = errorData.error || errorMessage;
+          } catch {
+            // JSON以外のレスポンスの場合はデフォルトメッセージを使用
+          }
+          throw new Error(errorMessage);
+        }
+
+        const quoteData = await response.json();
+        if (isMounted) {
+          setQuote(quoteData);
+
+          // フォームの初期値を設定
+          form.reset(toFormValuesFromQuote(quoteData));
+        }
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : '見積書の取得に失敗しました';
+        if (isMounted) {
+          setFetchError(message);
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void fetchQuote();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [quoteId, form]);
+
+  const onSubmit = async (data: QuoteFormData) => {
+    try {
+      setSubmitError(undefined);
+      setSubmitSuccess(false);
+
+      // モードに応じてAPIエンドポイントとメソッドを切り替え
+      const url = isEditMode ? `/api/quotes/${quoteId}` : '/api/quotes';
+      const method = isEditMode ? 'PUT' : 'POST';
+      const successMessage = isEditMode
+        ? '見積書が正常に更新されました！'
+        : '見積書が正常に作成されました！';
+      const errorMessage = isEditMode
+        ? '見積書の更新に失敗しました'
+        : '見積書の作成に失敗しました';
+
+      const response = await fetch(url, {
+        method,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(omitUndefined(data)),
+      });
+
+      if (!response.ok) {
+        let apiErrorMessage = errorMessage;
+        try {
+          const errorData = await response.json();
+          apiErrorMessage = errorData.error || apiErrorMessage;
+        } catch {
+          // JSON以外のレスポンスの場合はデフォルトメッセージを使用
+        }
+        throw new Error(apiErrorMessage);
+      }
+
+      setSubmitSuccess(true);
+
+      toast.success(successMessage);
+
+      setTimeout(() => {
+        router.push('/dashboard'); // 今後見積書一覧ページに変更
+      }, 2000);
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : isEditMode
+            ? '見積書の更新に失敗しました'
+            : '見積書の作成に失敗しました';
+      setSubmitError(message);
+      toast.error(message);
+    }
+  };
+
+  const onReset = () => {
+    if (isEditMode && quote) {
+      // 編集モード: 元のデータに戻す
+      form.reset(toFormValuesFromQuote(quote));
+    } else {
+      // 新規作成モード: 既定値に戻す
+      form.reset(defaultCreateValues);
+    }
+    setSubmitError(undefined);
+    setSubmitSuccess(false);
+  };
+
+  const clearMessages = () => {
+    setSubmitError(undefined);
+    setSubmitSuccess(false);
+    setFetchError(undefined);
+  };
+
+  return {
+    form,
+    state: {
+      isSubmitting: form.formState.isSubmitting,
+      submitError,
+      submitSuccess,
+      isLoading,
+      fetchError,
+      quote,
+    },
+    actions: {
+      onSubmit: form.handleSubmit(onSubmit),
+      onReset,
+      clearMessages,
+    },
+  };
+}

--- a/lib/domains/quotes/types.ts
+++ b/lib/domains/quotes/types.ts
@@ -281,6 +281,17 @@ export function convertPrismaQuoteItemToQuoteItem(
 }
 
 /**
+ * UI層で使用するフォーム型制約（コンポーネント用）
+ * React Hook Form の Control<T> のジェネリクス制約として使用
+ */
+export interface QuoteBasicsShape {
+  clientId: string;
+  issueDate: Date;
+  expiryDate?: Date;
+  notes?: string;
+}
+
+/**
  * エクスポート型定義
  */
 export type {

--- a/lib/shared/utils/date.ts
+++ b/lib/shared/utils/date.ts
@@ -93,3 +93,53 @@ export function formatRelativeTime(dateString: string): string | null {
     return 'たった今';
   }
 }
+
+/**
+ * 日付を <input type="date"> 用の "YYYY-MM-DD" にローカルタイムで変換
+ * タイムゾーンのずれを考慮してローカル日付を正しく表示
+ * @param date Dateオブジェクト
+ * @returns "YYYY-MM-DD" 形式の文字列、または無効な日付の場合は空文字列
+ */
+export function toDateInputValue(date: Date): string {
+  if (!(date instanceof Date) || isNaN(date.getTime())) {
+    // input 要素の「空」を表現
+    return '';
+  }
+  const tzOffset = date.getTimezoneOffset();
+  const local = new Date(date.getTime() - tzOffset * 60_000);
+  return local.toISOString().slice(0, 10);
+}
+
+/**
+ * "YYYY-MM-DD" をローカルタイムの Date に変換
+ * input type="date" からの値を正しいローカル日付に変換
+ * 不正日付（2024-02-31など）は自動補正せずにundefinedを返す
+ * @param value "YYYY-MM-DD" 形式の文字列
+ * @returns ローカルタイムのDateオブジェクト、または不正/空の場合undefined
+ */
+export function fromDateInputValue(value: string): Date | undefined {
+  const v = value?.trim();
+  if (!v) return undefined;
+
+  // 厳密な "YYYY-MM-DD" フォーマットチェック
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(v);
+  if (!m) return undefined;
+
+  const y = Number(m[1]);
+  const mm = Number(m[2]);
+  const dd = Number(m[3]);
+
+  const date = new Date(y, mm - 1, dd);
+
+  // ラウンドトリップ検証（自動補正を検出）
+  // 例: 2024-02-31 → 2024-03-02 になる場合は不正として弾く
+  if (
+    date.getFullYear() !== y ||
+    date.getMonth() !== mm - 1 ||
+    date.getDate() !== dd
+  ) {
+    return undefined;
+  }
+
+  return date;
+}

--- a/lib/shared/utils/date.ts
+++ b/lib/shared/utils/date.ts
@@ -143,3 +143,16 @@ export function fromDateInputValue(value: string): Date | undefined {
 
   return date;
 }
+
+/**
+ * 日付をAPI送信用の"YYYY-MM-DD"文字列に変換
+ * タイムゾーンのずれを考慮してローカル日付を正しくAPI送信
+ * @param date Dateオブジェクト
+ * @returns "YYYY-MM-DD" 形式の文字列、または無効な日付の場合はnull
+ */
+export function toApiDateString(date: Date | null | undefined): string | null {
+  if (!date || !(date instanceof Date) || isNaN(date.getTime())) {
+    return null;
+  }
+  return toDateInputValue(date); // 既存のtoDateInputValueを再利用
+}


### PR DESCRIPTION
## 概要

- 見積書作成フォーム(/dashboard/quotes/new)を実装
- 取引先選択ドロップダウンコンポーネント追加
- 自動採番機能に対応したフォーム設計

## 背景

- #59 見積書作成フォーム実装の要望に対応
- 見積書CRUD API（#71）に続くフロントエンド実装
- 取引先管理機能との統合が必要

## 実装内容

### 新規追加コンポーネント
- `QuoteForm`: メインフォームコンポーネント（BaseForm統合）
- `ClientSelector`: 取引先選択ドロップダウン（API統合・新規作成リンク付き）
- `QuoteBasicInfoFields`: 基本情報入力フィールド（取引先・発行日・有効期限・備考）
- `QuoteFormFields`: フィールド統合コンポーネント（将来拡張対応）

### 技術実装詳細
- React Hook Form + Zod による型安全フォーム
- UI専用スキーマ（`form-schemas.ts`）でRHF型整合性を確保
- ジェネリクス＋最小形制約（`QuoteBasicsShape`）で拡張性を担保
- タイムゾーン対応の日付処理（`toDateInputValue`/`fromDateInputValue`）
- メモリリーク対策（useEffectクリーンアップ実装）
- ARIA属性によるアクセシビリティ対応

### API統合
- `/api/clients` と連携した取引先一覧取得
- `/api/quotes` への見積書作成API呼び出し
- 適切なクエリパラメータ（page/limit/sort）での呼び出し

## スクリーンショット（UI変更がある場合）

| Before | After |
| ------ | ----- |
| 見積書作成画面なし | 見積書作成フォーム完成（取引先選択・日付入力・バリデーション対応） |

## チェックリスト（必須確認事項）

- [x] 関連Issueにリンクされている
- [x] CIが通過している（test / lint / build）
- [x] 本番環境に影響がないことを確認済み
- [x] UI/UX上の重大な変更がある場合、他メンバーと共有済み
- [x] テストコードが追加 or テスト不要の理由を明記した

## 関連Issue / PR

- Close #59

## 補足

### テスト不要の理由
- フォームコンポーネントはReact Hook Form公式パターンに準拠
- 基盤UIはBaseForm（既存テスト済み）を使用
- API統合部分は既存のhooksパターンを踏襲

### 設計判断
- フォーム専用スキーマを導入してRHF v7 + zodResolver v5の型問題を解決
- 将来の品目行UI（#60）・計算機能（#61）拡張に備えてジェネリクス設計を採用
- BaseFormの成功メッセージ重複を修正（toast統一）

### 今後の予定
- #60: 品目行UI実装でQuoteFormFieldsを拡張
- #61: 計算・プレビュー機能追加
- #62: 一覧・ステータス管理画面

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - ダッシュボードに「新規見積書作成」ページを追加。
  - 見積書フォームを追加（取引先選択、発行日・有効期限、備考）。有効期限は発行日以降のみ許可。日本語のバリデーションメッセージ対応。
  - 取引先セレクターを実装。キーボード/スクリーンリーダー対応、外側クリックで閉じる、「新しい取引先を作成」への導線付き。
  - 日付入力をローカルタイムで安定表示（YYYY‑MM‑DD）。送信成功時はダッシュボードへ遷移。

- 変更
  - 送信後の成功メッセージ自動表示を廃止。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->