### PR TITLE
feat: 請求書CRUD API・見積書複製・インボイス対応 (#63)

### DIFF
--- a/app/api/invoices/[id]/route.ts
+++ b/app/api/invoices/[id]/route.ts
@@ -1,0 +1,178 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { z } from 'zod';
+
+import {
+  invoiceSchemas,
+  includeSchema,
+  statusUpdateInvoiceSchema,
+} from '@/lib/domains/invoices/schemas';
+import {
+  getInvoice,
+  updateInvoice,
+  deleteInvoice,
+  updateInvoiceStatus,
+  updatePaymentInfo,
+} from '@/lib/domains/invoices/service';
+import { convertPrismaInvoiceToInvoice } from '@/lib/domains/invoices/types';
+import { buildIncludeRelations } from '@/lib/domains/invoices/utils';
+import { apiErrors, handleApiError } from '@/lib/shared/forms';
+import { requireUserCompany } from '@/lib/shared/utils/auth';
+
+// パラメータスキーマ
+const invoiceParamsSchema = z.object({
+  id: z.string().min(1, '請求書IDは必須です'),
+});
+
+interface RouteContext {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * 請求書詳細取得API
+ */
+export async function GET(request: NextRequest, context: RouteContext) {
+  try {
+    const { id: invoiceId } = invoiceParamsSchema.parse(await context.params);
+    const { company, error, status } = await requireUserCompany();
+    if (error) {
+      return NextResponse.json(error, { status });
+    }
+    const { searchParams } = new URL(request.url);
+
+    // includeパラメータの処理
+    const includeResult = includeSchema.safeParse({
+      include: searchParams.get('include'),
+    });
+
+    if (!includeResult.success) {
+      return NextResponse.json(
+        apiErrors.validation(includeResult.error.issues),
+        { status: 400 }
+      );
+    }
+
+    const includeRelations = buildIncludeRelations(includeResult.data.include);
+
+    // 請求書取得
+    const invoice = await getInvoice(invoiceId, company.id, includeRelations);
+
+    if (!invoice) {
+      return NextResponse.json(apiErrors.notFound('請求書'), { status: 404 });
+    }
+
+    return NextResponse.json({
+      data: convertPrismaInvoiceToInvoice(invoice),
+    });
+  } catch (error) {
+    return handleApiError(error, 'Invoice fetch');
+  }
+}
+
+/**
+ * 請求書更新API
+ */
+export async function PUT(request: NextRequest, context: RouteContext) {
+  try {
+    const { id: invoiceId } = invoiceParamsSchema.parse(await context.params);
+    const { company, error, status } = await requireUserCompany();
+    if (error) {
+      return NextResponse.json(error, { status });
+    }
+    const body = await request.json();
+
+    const validatedData = invoiceSchemas.update.parse(body);
+
+    const updatedInvoice = await updateInvoice(
+      invoiceId,
+      company.id,
+      validatedData
+    );
+    const publicInvoice = convertPrismaInvoiceToInvoice(updatedInvoice);
+
+    return NextResponse.json({
+      data: publicInvoice,
+      message: '請求書を更新しました',
+    });
+  } catch (error) {
+    return handleApiError(error, 'Invoice update');
+  }
+}
+
+/**
+ * 請求書削除API（論理削除）
+ */
+export async function DELETE(request: NextRequest, context: RouteContext) {
+  try {
+    const { id: invoiceId } = invoiceParamsSchema.parse(await context.params);
+    const { company, error, status } = await requireUserCompany();
+    if (error) {
+      return NextResponse.json(error, { status });
+    }
+
+    await deleteInvoice(invoiceId, company.id);
+
+    return NextResponse.json({
+      message: '請求書を削除しました',
+    });
+  } catch (error) {
+    return handleApiError(error, 'Invoice delete');
+  }
+}
+
+/**
+ * 請求書ステータス更新API
+ */
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  try {
+    const { id: invoiceId } = invoiceParamsSchema.parse(await context.params);
+    const { company, error, status } = await requireUserCompany();
+    if (error) {
+      return NextResponse.json(error, { status });
+    }
+    const body = await request.json();
+
+    // リクエストタイプによって処理を分岐
+    if ('status' in body && 'paymentDate' in body) {
+      // 支払情報更新
+      const validatedData = invoiceSchemas.updatePayment.parse(body);
+      const updatedInvoice = await updatePaymentInfo(
+        invoiceId,
+        company.id,
+        validatedData
+      );
+      const publicInvoice = convertPrismaInvoiceToInvoice(updatedInvoice);
+
+      return NextResponse.json({
+        data: publicInvoice,
+        message: '支払情報を更新しました',
+      });
+    } else if ('status' in body) {
+      // ステータス更新のみ
+      const validatedData = statusUpdateInvoiceSchema.parse(body);
+      const paymentDate = body.paymentDate
+        ? new Date(body.paymentDate)
+        : undefined;
+
+      const updatedInvoice = await updateInvoiceStatus(
+        invoiceId,
+        company.id,
+        validatedData.status,
+        paymentDate
+      );
+      const publicInvoice = convertPrismaInvoiceToInvoice(updatedInvoice);
+
+      return NextResponse.json({
+        data: publicInvoice,
+        message: 'ステータスを更新しました',
+      });
+    } else {
+      return NextResponse.json(
+        apiErrors.badRequest('statusまたはpaymentDateのいずれかが必要です'),
+        { status: 400 }
+      );
+    }
+  } catch (error) {
+    return handleApiError(error, 'Invoice status update');
+  }
+}

--- a/app/api/invoices/from-quote/[quoteId]/route.ts
+++ b/app/api/invoices/from-quote/[quoteId]/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { z } from 'zod';
+
+import { invoiceSchemas } from '@/lib/domains/invoices/schemas';
+import { createInvoiceFromQuote } from '@/lib/domains/invoices/service';
+import { convertPrismaInvoiceToInvoice } from '@/lib/domains/invoices/types';
+import { handleApiError } from '@/lib/shared/forms';
+import { requireUserCompany } from '@/lib/shared/utils/auth';
+
+// パラメータスキーマ
+const quoteParamsSchema = z.object({
+  quoteId: z.string().min(1, '見積書IDは必須です'),
+});
+
+interface RouteContext {
+  params: Promise<{ quoteId: string }>;
+}
+
+/**
+ * 見積書から請求書作成API
+ * 指定された見積書から新しい請求書を作成します
+ * 品目の選択的複製も対応
+ */
+export async function POST(request: NextRequest, context: RouteContext) {
+  try {
+    const { quoteId } = quoteParamsSchema.parse(await context.params);
+    const { company, error, status } = await requireUserCompany();
+    if (error) {
+      return NextResponse.json(error, { status });
+    }
+    const body = await request.json();
+
+    // リクエストボディのバリデーション
+    const validatedData = invoiceSchemas.createFromQuote.parse(body);
+
+    // 見積書から請求書を作成
+    const result = await createInvoiceFromQuote(
+      company.id,
+      quoteId,
+      validatedData
+    );
+
+    const publicInvoice = convertPrismaInvoiceToInvoice(result.invoice);
+
+    return NextResponse.json(
+      {
+        data: publicInvoice,
+        duplicatedItemsCount: result.duplicatedItemsCount,
+        selectedItemsCount: result.selectedItemsCount,
+        message: `見積書から請求書を作成しました（${result.duplicatedItemsCount}件の品目を複製）`,
+      },
+      {
+        status: 201,
+        headers: { Location: `/api/invoices/${publicInvoice.id}` },
+      }
+    );
+  } catch (error) {
+    return handleApiError(error, 'Invoice creation from quote');
+  }
+}

--- a/app/api/invoices/route.ts
+++ b/app/api/invoices/route.ts
@@ -1,0 +1,160 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import {
+  invoiceSchemas,
+  paginationSchema,
+  invoiceSearchSchema,
+} from '@/lib/domains/invoices/schemas';
+import {
+  createInvoice,
+  getInvoices,
+  updateOverdueInvoices,
+} from '@/lib/domains/invoices/service';
+import { convertPrismaInvoiceToInvoice } from '@/lib/domains/invoices/types';
+import {
+  buildInvoiceSearchWhere,
+  buildOrderBy,
+  buildIncludeRelations,
+} from '@/lib/domains/invoices/utils';
+import { PAGINATION } from '@/lib/shared/constants';
+import { apiErrors, handleApiError } from '@/lib/shared/forms';
+import { requireUserCompany } from '@/lib/shared/utils/auth';
+
+/**
+ * 請求書作成API
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const { company, error, status } = await requireUserCompany();
+    if (error) {
+      return NextResponse.json(error, { status });
+    }
+
+    const body = await request.json();
+    const validatedData = invoiceSchemas.create.parse(body);
+
+    const invoice = await createInvoice(company.id, validatedData);
+    const publicInvoice = convertPrismaInvoiceToInvoice(invoice);
+
+    return NextResponse.json(
+      {
+        data: publicInvoice,
+        message: '請求書を作成しました',
+      },
+      {
+        status: 201,
+        headers: { Location: `/api/invoices/${publicInvoice.id}` },
+      }
+    );
+  } catch (error) {
+    return handleApiError(error, 'Invoice creation');
+  }
+}
+
+/**
+ * 請求書一覧取得API
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const { company, error, status } = await requireUserCompany();
+    if (error) {
+      return NextResponse.json(error, { status });
+    }
+
+    // 期限超過請求書の自動ステータス更新
+    await updateOverdueInvoices(company.id);
+
+    const { searchParams } = new URL(request.url);
+
+    // パラメータの解析（nullを適切に処理）
+    const getParam = (key: string) => {
+      const value = searchParams.get(key);
+      return value === null || value.trim() === '' ? undefined : value;
+    };
+
+    // パラメータのバリデーション
+    const paginationResult = paginationSchema.safeParse({
+      page: getParam('page'),
+      limit: getParam('limit'),
+    });
+
+    const searchResult = invoiceSearchSchema.safeParse({
+      q: getParam('q'),
+      status: getParam('status'),
+      clientId: getParam('clientId'),
+      quoteId: getParam('quoteId'),
+      dateFrom: getParam('dateFrom'),
+      dateTo: getParam('dateTo'),
+      dueDateFrom: getParam('dueDateFrom'),
+      dueDateTo: getParam('dueDateTo'),
+      sort: getParam('sort'),
+      include: getParam('include'),
+    });
+
+    if (!paginationResult.success || !searchResult.success) {
+      return NextResponse.json(
+        apiErrors.validation([
+          ...(paginationResult.error?.issues || []),
+          ...(searchResult.error?.issues || []),
+        ]),
+        { status: 400 }
+      );
+    }
+
+    const { page, limit } = paginationResult.data;
+    const take = Math.min(limit, PAGINATION.MAX_LIMIT);
+    const skip = Math.max(0, (page - 1) * take);
+    const {
+      q,
+      status: invoiceStatus,
+      clientId,
+      quoteId,
+      dateFrom,
+      dateTo,
+      dueDateFrom,
+      dueDateTo,
+      sort,
+      include,
+    } = searchResult.data;
+
+    // 検索条件とソート条件、関連データ取得設定の構築
+    const where = buildInvoiceSearchWhere(company.id, {
+      query: q,
+      status: invoiceStatus,
+      clientId,
+      quoteId,
+      dateFrom,
+      dateTo,
+      dueDateFrom,
+      dueDateTo,
+    });
+    const orderBy = buildOrderBy(sort);
+    const includeRelations = buildIncludeRelations(include);
+
+    // データ取得とカウント（並列実行）
+    const { invoices, total } = await getInvoices(
+      company.id,
+      where,
+      orderBy,
+      includeRelations,
+      {
+        skip,
+        take,
+      }
+    );
+
+    const totalPages = take > 0 ? Math.ceil(total / take) : 0;
+
+    return NextResponse.json({
+      data: invoices.map(convertPrismaInvoiceToInvoice),
+      pagination: {
+        total,
+        page,
+        limit: take, // 実際に使用されたlimit値
+        totalPages,
+      },
+    });
+  } catch (error) {
+    return handleApiError(error, 'Invoices fetch');
+  }
+}

--- a/app/api/invoices/search/route.ts
+++ b/app/api/invoices/search/route.ts
@@ -1,0 +1,112 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { invoiceSearchSchema } from '@/lib/domains/invoices/schemas';
+import {
+  getInvoices,
+  updateOverdueInvoices,
+} from '@/lib/domains/invoices/service';
+import { convertPrismaInvoiceToInvoice } from '@/lib/domains/invoices/types';
+import {
+  buildInvoiceSearchWhere,
+  buildOrderBy,
+  buildIncludeRelations,
+} from '@/lib/domains/invoices/utils';
+import { apiErrors, handleApiError } from '@/lib/shared/forms';
+import { requireUserCompany } from '@/lib/shared/utils/auth';
+
+/**
+ * 請求書検索API
+ * クエリパラメータに基づく柔軟な検索機能を提供
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const { company, error, status } = await requireUserCompany();
+    if (error) {
+      return NextResponse.json(error, { status });
+    }
+
+    // 期限超過請求書の自動ステータス更新
+    await updateOverdueInvoices(company.id);
+
+    const { searchParams } = new URL(request.url);
+
+    // パラメータの解析（nullを適切に処理）
+    const getParam = (key: string) => {
+      const value = searchParams.get(key);
+      return value === null || value.trim() === '' ? undefined : value;
+    };
+
+    // 検索パラメータのバリデーション
+    const searchResult = invoiceSearchSchema.safeParse({
+      q: getParam('q'),
+      status: getParam('status'),
+      clientId: getParam('clientId'),
+      quoteId: getParam('quoteId'),
+      dateFrom: getParam('dateFrom'),
+      dateTo: getParam('dateTo'),
+      dueDateFrom: getParam('dueDateFrom'),
+      dueDateTo: getParam('dueDateTo'),
+      sort: getParam('sort'),
+      include: getParam('include'),
+    });
+
+    if (!searchResult.success) {
+      return NextResponse.json(
+        apiErrors.validation(searchResult.error.issues),
+        { status: 400 }
+      );
+    }
+
+    const {
+      q,
+      status: invoiceStatus,
+      clientId,
+      quoteId,
+      dateFrom,
+      dateTo,
+      dueDateFrom,
+      dueDateTo,
+      sort,
+      include,
+    } = searchResult.data;
+
+    // 検索条件とソート条件、関連データ取得設定の構築
+    const where = buildInvoiceSearchWhere(company.id, {
+      query: q,
+      status: invoiceStatus,
+      clientId,
+      quoteId,
+      dateFrom,
+      dateTo,
+      dueDateFrom,
+      dueDateTo,
+    });
+    const orderBy = buildOrderBy(sort);
+    const includeRelations = buildIncludeRelations(include);
+
+    // limitパラメータの処理（検索APIではページネーションなしまたは制限付き）
+    const limitParam = getParam('limit');
+    const limit = limitParam ? Math.min(parseInt(limitParam, 10), 100) : 50; // デフォルト50件、最大100件
+
+    // データ取得
+    const { invoices, total } = await getInvoices(
+      company.id,
+      where,
+      orderBy,
+      includeRelations,
+      {
+        skip: 0,
+        take: limit,
+      }
+    );
+
+    return NextResponse.json({
+      data: invoices.map(convertPrismaInvoiceToInvoice),
+      total,
+      limit,
+      hasMore: total > limit,
+    });
+  } catch (error) {
+    return handleApiError(error, 'Invoice search');
+  }
+}

--- a/app/api/invoices/search/route.ts
+++ b/app/api/invoices/search/route.ts
@@ -86,7 +86,11 @@ export async function GET(request: NextRequest) {
 
     // limitパラメータの処理（検索APIではページネーションなしまたは制限付き）
     const limitParam = getParam('limit');
-    const limit = limitParam ? Math.min(parseInt(limitParam, 10), 100) : 50; // デフォルト50件、最大100件
+    const parsedLimit = limitParam ? Number.parseInt(limitParam, 10) : NaN;
+    // 整数でない/NaN の場合はデフォルト。整数なら [1,100] にクランプ
+    const limit = Number.isInteger(parsedLimit)
+      ? Math.min(Math.max(parsedLimit, 1), 100)
+      : 50; // デフォルト50件、最小1件、最大100件
 
     // データ取得
     const { invoices, total } = await getInvoices(

--- a/lib/domains/invoices/schemas.ts
+++ b/lib/domains/invoices/schemas.ts
@@ -80,14 +80,18 @@ export const updateInvoiceItemSchema = baseInvoiceItemSchema
   .partial()
   .refine(
     (data) => {
-      if (
-        data.discountAmount !== undefined &&
-        data.unitPrice !== undefined &&
-        data.quantity !== undefined
-      ) {
-        return data.discountAmount <= data.unitPrice * data.quantity;
+      // 割引額が設定されている場合のみ検証
+      if (data.discountAmount === undefined) {
+        return true;
       }
-      return true;
+
+      // 既存の値を取得する必要があるため、検証をスキップ
+      // （実際のビジネスロジック層で既存値との結合後に検証）
+      if (data.unitPrice === undefined || data.quantity === undefined) {
+        return true;
+      }
+
+      return data.discountAmount <= data.unitPrice * data.quantity;
     },
     {
       message: '割引額は品目合計金額を超えることはできません',
@@ -343,14 +347,18 @@ export const patchInvoiceItemSchema = baseInvoiceItemSchema
   .partial()
   .refine(
     (data) => {
-      if (
-        data.discountAmount !== undefined &&
-        data.unitPrice !== undefined &&
-        data.quantity !== undefined
-      ) {
-        return data.discountAmount <= data.unitPrice * data.quantity;
+      // 割引額が設定されている場合のみ検証
+      if (data.discountAmount === undefined) {
+        return true;
       }
-      return true;
+
+      // 既存の値を取得する必要があるため、検証をスキップ
+      // （実際のビジネスロジック層で既存値との結合後に検証）
+      if (data.unitPrice === undefined || data.quantity === undefined) {
+        return true;
+      }
+
+      return data.discountAmount <= data.unitPrice * data.quantity;
     },
     {
       message: '割引額は品目合計金額を超えることはできません',

--- a/lib/domains/invoices/schemas.ts
+++ b/lib/domains/invoices/schemas.ts
@@ -1,0 +1,378 @@
+import { z } from 'zod';
+
+import { PAGINATION } from '@/lib/shared/constants';
+
+/**
+ * 請求書基本スキーマ
+ */
+export const baseInvoiceSchema = z.object({
+  clientId: z.string().min(1, 'クライアントIDは必須です'),
+  issueDate: z.coerce.date(),
+  dueDate: z.preprocess(
+    (val) => (val === null || val === '' ? undefined : val),
+    z.coerce.date().optional()
+  ),
+  notes: z.string().optional(),
+  quoteId: z.string().optional(), // 見積書からの複製時に使用
+});
+
+/**
+ * 請求書作成スキーマ
+ */
+export const createInvoiceSchema = baseInvoiceSchema.refine(
+  (data) => !data.dueDate || data.issueDate <= data.dueDate,
+  {
+    message: '支払期限は発行日以降である必要があります',
+    path: ['dueDate'],
+  }
+);
+
+/**
+ * 請求書更新スキーマ
+ */
+export const updateInvoiceSchema = baseInvoiceSchema
+  .partial()
+  .refine(
+    (data) =>
+      !data.dueDate || !data.issueDate || data.issueDate <= data.dueDate,
+    {
+      message: '支払期限は発行日以降である必要があります',
+      path: ['dueDate'],
+    }
+  )
+  .and(z.object({ updatedAt: z.coerce.date() }));
+
+/**
+ * 請求書品目基本スキーマ
+ */
+export const baseInvoiceItemSchema = z.object({
+  description: z.string().min(1, '品目名は必須です'),
+  quantity: z.coerce.number().positive('数量は正の数である必要があります'),
+  unitPrice: z.coerce.number().nonnegative('単価は0以上である必要があります'),
+  taxCategory: z
+    .enum(['STANDARD', 'REDUCED', 'EXEMPT', 'NON_TAX'])
+    .default('STANDARD'),
+  taxRate: z.coerce.number().min(0).max(100).optional(),
+  discountAmount: z.coerce
+    .number()
+    .nonnegative('割引額は0以上である必要があります')
+    .default(0),
+  unit: z.string().optional(),
+  sku: z.string().optional(),
+  sortOrder: z.coerce.number().int().nonnegative().default(0),
+});
+
+/**
+ * 請求書品目作成スキーマ
+ */
+export const createInvoiceItemSchema = baseInvoiceItemSchema.refine(
+  (data) => data.discountAmount <= data.unitPrice * data.quantity,
+  {
+    message: '割引額は品目合計金額を超えることはできません',
+    path: ['discountAmount'],
+  }
+);
+
+/**
+ * 請求書品目更新スキーマ
+ */
+export const updateInvoiceItemSchema = baseInvoiceItemSchema
+  .partial()
+  .refine(
+    (data) => {
+      if (
+        data.discountAmount !== undefined &&
+        data.unitPrice !== undefined &&
+        data.quantity !== undefined
+      ) {
+        return data.discountAmount <= data.unitPrice * data.quantity;
+      }
+      return true;
+    },
+    {
+      message: '割引額は品目合計金額を超えることはできません',
+      path: ['discountAmount'],
+    }
+  )
+  .and(z.object({ updatedAt: z.coerce.date() }));
+
+/**
+ * 請求書品目バルク処理スキーマ
+ */
+const bulkCreateItemSchema = z.object({
+  action: z.literal('create'),
+  data: createInvoiceItemSchema,
+});
+
+const bulkUpdateItemSchema = z.object({
+  action: z.literal('update'),
+  id: z.string().min(1, '更新時はIDが必須です'),
+  data: updateInvoiceItemSchema,
+});
+
+const bulkDeleteItemSchema = z.object({
+  action: z.literal('delete'),
+  id: z.string().min(1, '削除時はIDが必須です'),
+});
+
+export const bulkInvoiceItemsSchema = z.object({
+  items: z
+    .array(
+      z.discriminatedUnion('action', [
+        bulkCreateItemSchema,
+        bulkUpdateItemSchema,
+        bulkDeleteItemSchema,
+      ])
+    )
+    .min(1, '最低1つの品目が必要です'),
+});
+
+/**
+ * CSVインポートスキーマ
+ */
+export const csvImportSchema = z.object({
+  file: z.instanceof(File).refine(
+    (file) => {
+      const t = (file.type || '').toLowerCase();
+      return (
+        file.name.toLowerCase().endsWith('.csv') ||
+        t === 'text/csv' ||
+        t === 'application/csv' ||
+        t === 'application/vnd.ms-excel'
+      );
+    },
+    {
+      message: 'CSVファイルを選択してください',
+    }
+  ),
+  overwrite: z.boolean().default(false), // 既存品目を上書きするか
+});
+
+/**
+ * 請求書検索パラメータスキーマ
+ */
+export const invoiceSearchSchema = z
+  .object({
+    q: z.preprocess(
+      (v) => (typeof v === 'string' && v.trim() === '' ? undefined : v),
+      z.string().optional()
+    ),
+    status: z.preprocess(
+      (v) => (typeof v === 'string' && v.trim() === '' ? undefined : v),
+      z.enum(['DRAFT', 'SENT', 'PAID', 'OVERDUE']).optional()
+    ),
+    clientId: z.preprocess(
+      (v) => (typeof v === 'string' && v.trim() === '' ? undefined : v),
+      z.string().optional()
+    ),
+    quoteId: z.preprocess(
+      (v) => (typeof v === 'string' && v.trim() === '' ? undefined : v),
+      z.string().optional()
+    ),
+    dateFrom: z.coerce.date().optional(),
+    dateTo: z.coerce.date().optional(),
+    dueDateFrom: z.coerce.date().optional(),
+    dueDateTo: z.coerce.date().optional(),
+    sort: z
+      .enum([
+        'issueDate_asc',
+        'issueDate_desc',
+        'dueDate_asc',
+        'dueDate_desc',
+        'createdAt_asc',
+        'createdAt_desc',
+        'invoiceNumber_asc',
+        'invoiceNumber_desc',
+      ])
+      .default('createdAt_desc'),
+    include: z.preprocess(
+      (val) => {
+        if (Array.isArray(val)) {
+          return val
+            .flatMap((v) => String(v).split(','))
+            .map((s) => s.trim())
+            .filter(Boolean);
+        }
+        if (typeof val === 'string') {
+          return val
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean);
+        }
+        return [];
+      },
+      z.array(z.enum(['client', 'items', 'quote']))
+    ),
+  })
+  .refine((d) => !(d.dateFrom && d.dateTo) || d.dateFrom <= d.dateTo, {
+    path: ['dateTo'],
+    message: '発行日終了日は開始日以降である必要があります',
+  })
+  .refine(
+    (d) => !(d.dueDateFrom && d.dueDateTo) || d.dueDateFrom <= d.dueDateTo,
+    {
+      path: ['dueDateTo'],
+      message: '支払期限終了日は開始日以降である必要があります',
+    }
+  );
+
+/**
+ * ページネーションスキーマ
+ */
+export const paginationSchema = z.object({
+  page: z
+    .string()
+    .nullable()
+    .optional()
+    .default(String(PAGINATION.DEFAULT_PAGE))
+    .transform(Number)
+    .pipe(z.number().min(1)),
+  limit: z
+    .string()
+    .nullable()
+    .optional()
+    .default(String(PAGINATION.DEFAULT_LIMIT))
+    .transform(Number)
+    .pipe(z.number().min(1).max(PAGINATION.MAX_LIMIT)),
+});
+
+/**
+ * includeパラメータスキーマ
+ */
+export const includeSchema = z.object({
+  include: z.preprocess(
+    (val) =>
+      typeof val === 'string'
+        ? val
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean)
+        : [],
+    z.array(z.enum(['client', 'items', 'quote']))
+  ),
+});
+
+/**
+ * 見積書から請求書作成スキーマ
+ */
+export const createInvoiceFromQuoteSchema = z
+  .object({
+    issueDate: z.coerce.date(),
+    dueDate: z.preprocess(
+      (val) => (val === null || val === '' ? undefined : val),
+      z.coerce.date().optional()
+    ),
+    notes: z.string().optional(),
+    selectedItemIds: z
+      .array(z.string())
+      .min(1, '最低1つの品目を選択してください')
+      .optional(), // 未指定時は全品目を複製
+  })
+  .refine((data) => !data.dueDate || data.issueDate <= data.dueDate, {
+    message: '支払期限は発行日以降である必要があります',
+    path: ['dueDate'],
+  });
+
+/**
+ * 支払情報更新スキーマ
+ */
+export const updatePaymentSchema = z
+  .object({
+    status: z.enum(['DRAFT', 'SENT', 'PAID', 'OVERDUE']),
+    paymentDate: z.preprocess(
+      (val) => (val === null || val === '' ? undefined : val),
+      z.coerce.date().optional()
+    ),
+  })
+  .refine(
+    (data) => {
+      if (data.status === 'PAID' && !data.paymentDate) {
+        return false;
+      }
+      return true;
+    },
+    {
+      message: '支払済みステータスには支払日が必要です',
+      path: ['paymentDate'],
+    }
+  );
+
+/**
+ * 型エクスポート
+ */
+export type InvoiceData = z.infer<typeof createInvoiceSchema>;
+export type InvoiceUpdateData = z.infer<typeof updateInvoiceSchema>;
+export type InvoiceItemData = z.infer<typeof createInvoiceItemSchema>;
+export type InvoiceItemUpdateData = z.infer<typeof updateInvoiceItemSchema>;
+export type BulkInvoiceItemsData = z.infer<typeof bulkInvoiceItemsSchema>;
+export type InvoiceSearchParams = z.infer<typeof invoiceSearchSchema>;
+export type CreateInvoiceFromQuoteData = z.infer<
+  typeof createInvoiceFromQuoteSchema
+>;
+export type UpdatePaymentData = z.infer<typeof updatePaymentSchema>;
+
+/**
+ * 請求書ステータス更新スキーマ
+ */
+export const statusUpdateInvoiceSchema = z.object({
+  status: z.enum(['DRAFT', 'SENT', 'PAID', 'OVERDUE']),
+});
+
+/**
+ * スキーマ集約オブジェクト
+ */
+export const invoiceSchemas = {
+  create: createInvoiceSchema,
+  update: updateInvoiceSchema,
+  statusUpdate: statusUpdateInvoiceSchema,
+  createFromQuote: createInvoiceFromQuoteSchema,
+  updatePayment: updatePaymentSchema,
+};
+
+export const invoiceItemSchemas = {
+  create: createInvoiceItemSchema,
+  update: updateInvoiceItemSchema,
+  bulk: bulkInvoiceItemsSchema,
+};
+
+/**
+ * 品目の部分更新（単一）: 並び順の変更は除外
+ */
+export const patchInvoiceItemSchema = baseInvoiceItemSchema
+  .omit({ sortOrder: true })
+  .partial()
+  .refine(
+    (data) => {
+      if (
+        data.discountAmount !== undefined &&
+        data.unitPrice !== undefined &&
+        data.quantity !== undefined
+      ) {
+        return data.discountAmount <= data.unitPrice * data.quantity;
+      }
+      return true;
+    },
+    {
+      message: '割引額は品目合計金額を超えることはできません',
+      path: ['discountAmount'],
+    }
+  )
+  .and(z.object({ updatedAt: z.coerce.date() }));
+
+/**
+ * 品目の並び順一括更新（部分更新）
+ */
+export const reorderInvoiceItemsSchema = z.object({
+  items: z
+    .array(
+      z.object({
+        id: z.string().min(1, 'IDは必須です'),
+        sortOrder: z.coerce.number().int().nonnegative(),
+        updatedAt: z.coerce.date(),
+      })
+    )
+    .min(1, '最低1つの品目が必要です'),
+});
+
+export type InvoiceItemPatchData = z.infer<typeof patchInvoiceItemSchema>;
+export type ReorderInvoiceItemsData = z.infer<typeof reorderInvoiceItemsSchema>;

--- a/lib/domains/invoices/service.ts
+++ b/lib/domains/invoices/service.ts
@@ -1,0 +1,884 @@
+import {
+  Prisma,
+  InvoiceStatus,
+  type InvoiceItem as PrismaInvoiceItem,
+} from '@prisma/client';
+
+import { httpError } from '@/lib/shared/forms';
+import { prisma } from '@/lib/shared/prisma';
+import { ConflictError, NotFoundError } from '@/lib/shared/utils/errors';
+
+import {
+  generateInvoiceNumber,
+  calculateTax,
+  normalizeSortOrder,
+  isValidStatusTransition,
+  requiresItemsForTransition,
+  requiresNumberGenerationForTransition,
+} from './utils';
+
+import type { ReorderInvoiceItemsData } from './schemas';
+import type {
+  InvoiceWithRelations,
+  InvoiceData,
+  InvoiceUpdateData,
+  InvoiceItemData,
+  InvoiceItemUpdateData,
+  TaxCalculationResult,
+  InvoiceIncludeConfig,
+  InvoiceFilterConditions,
+  CreateInvoiceFromQuoteData,
+  CreateInvoiceFromQuoteResult,
+  UpdatePaymentData,
+} from './types';
+
+/**
+ * 請求書サービス層
+ * データベース操作とビジネスロジックを抽象化
+ */
+
+/**
+ * 請求書を作成
+ */
+export async function createInvoice(
+  companyId: string,
+  data: InvoiceData
+): Promise<InvoiceWithRelations> {
+  // クライアントの存在確認
+  const client = await prisma.client.findFirst({
+    where: {
+      id: data.clientId,
+      companyId,
+      deletedAt: null,
+    },
+  });
+
+  if (!client) {
+    throw new NotFoundError('指定されたクライアントが見つかりません');
+  }
+
+  // 見積書からの作成時は見積書の存在確認
+  if (data.quoteId) {
+    const quote = await prisma.quote.findFirst({
+      where: {
+        id: data.quoteId,
+        companyId,
+        deletedAt: null,
+      },
+    });
+
+    if (!quote) {
+      throw new NotFoundError('指定された見積書が見つかりません');
+    }
+  }
+
+  // 請求書を作成（DRAFT状態、仮番号を一意に採番）
+  const draftNumber = `DRAFT-${Date.now()}-${Math.random()
+    .toString(36)
+    .slice(2, 8)}`;
+  const invoice = await prisma.invoice.create({
+    data: {
+      companyId,
+      clientId: data.clientId,
+      quoteId: data.quoteId,
+      invoiceNumber: draftNumber,
+      issueDate: data.issueDate,
+      dueDate: data.dueDate,
+      notes: data.notes,
+      status: 'DRAFT',
+    },
+    include: {
+      client: true,
+      items: {
+        orderBy: { sortOrder: 'asc' },
+      },
+      quote: {
+        select: {
+          id: true,
+          quoteNumber: true,
+          issueDate: true,
+          status: true,
+        },
+      },
+    },
+  });
+
+  return invoice as InvoiceWithRelations;
+}
+
+/**
+ * 見積書から請求書を作成
+ */
+export async function createInvoiceFromQuote(
+  companyId: string,
+  quoteId: string,
+  data: CreateInvoiceFromQuoteData
+): Promise<CreateInvoiceFromQuoteResult> {
+  return await prisma.$transaction(async (tx) => {
+    // 見積書の存在確認と品目取得
+    const quote = await tx.quote.findFirst({
+      where: {
+        id: quoteId,
+        companyId,
+        deletedAt: null,
+      },
+      include: {
+        items: {
+          orderBy: { sortOrder: 'asc' },
+        },
+      },
+    });
+
+    if (!quote) {
+      throw new NotFoundError('指定された見積書が見つかりません');
+    }
+
+    if (quote.items.length === 0) {
+      throw httpError(400, '見積書に品目が登録されていません');
+    }
+
+    // 複製対象品目の決定
+    const sourceItems = data.selectedItemIds
+      ? quote.items.filter((item) => data.selectedItemIds!.includes(item.id))
+      : quote.items;
+
+    if (sourceItems.length === 0) {
+      throw httpError(400, '複製する品目が選択されていません');
+    }
+
+    // 請求書番号の仮採番
+    const draftNumber = `DRAFT-${Date.now()}-${Math.random()
+      .toString(36)
+      .slice(2, 8)}`;
+
+    // 請求書を作成
+    const invoice = await tx.invoice.create({
+      data: {
+        companyId,
+        clientId: quote.clientId,
+        quoteId: quote.id,
+        invoiceNumber: draftNumber,
+        issueDate: data.issueDate,
+        dueDate: data.dueDate,
+        notes: data.notes,
+        status: 'DRAFT',
+      },
+      include: {
+        client: true,
+        items: {
+          orderBy: { sortOrder: 'asc' },
+        },
+        quote: {
+          select: {
+            id: true,
+            quoteNumber: true,
+            issueDate: true,
+            status: true,
+          },
+        },
+      },
+    });
+
+    // 品目を複製
+    for (let i = 0; i < sourceItems.length; i++) {
+      const sourceItem = sourceItems[i];
+      await tx.invoiceItem.create({
+        data: {
+          invoiceId: invoice.id,
+          description: sourceItem.description,
+          quantity: sourceItem.quantity,
+          unitPrice: sourceItem.unitPrice,
+          taxCategory: sourceItem.taxCategory,
+          taxRate: sourceItem.taxRate,
+          discountAmount: sourceItem.discountAmount,
+          unit: sourceItem.unit,
+          sku: sourceItem.sku,
+          sortOrder: i,
+        },
+      });
+    }
+
+    // 最新の請求書情報を取得（品目含む）
+    const createdInvoice = await tx.invoice.findUnique({
+      where: { id: invoice.id },
+      include: {
+        client: true,
+        items: {
+          orderBy: { sortOrder: 'asc' },
+        },
+        quote: {
+          select: {
+            id: true,
+            quoteNumber: true,
+            issueDate: true,
+            status: true,
+          },
+        },
+      },
+    });
+
+    if (!createdInvoice) {
+      throw new NotFoundError('作成した請求書が見つかりません');
+    }
+
+    return {
+      invoice: createdInvoice as InvoiceWithRelations,
+      duplicatedItemsCount: sourceItems.length,
+      selectedItemsCount: quote.items.length,
+    };
+  });
+}
+
+/**
+ * 請求書を更新
+ */
+export async function updateInvoice(
+  invoiceId: string,
+  companyId: string,
+  data: InvoiceUpdateData
+): Promise<InvoiceWithRelations> {
+  // 請求書の存在確認
+  const existingInvoice = await prisma.invoice.findFirst({
+    where: {
+      id: invoiceId,
+      companyId,
+      deletedAt: null,
+    },
+  });
+
+  if (!existingInvoice) {
+    throw new NotFoundError('請求書が見つかりません');
+  }
+
+  // クライアントが変更される場合は存在確認
+  if (data.clientId && data.clientId !== existingInvoice.clientId) {
+    const client = await prisma.client.findFirst({
+      where: {
+        id: data.clientId,
+        companyId,
+        deletedAt: null,
+      },
+    });
+
+    if (!client) {
+      throw new NotFoundError('指定されたクライアントが見つかりません');
+    }
+  }
+
+  // 楽観ロック: updatedAt 一致条件
+  const { updatedAt, ...updateData } = data;
+  const result = await prisma.invoice.updateMany({
+    where: {
+      id: invoiceId,
+      companyId,
+      deletedAt: null,
+      updatedAt,
+    },
+    data: updateData,
+  });
+
+  if (result.count === 0) {
+    throw new ConflictError(
+      '更新競合が発生しました。最新の状態を取得してから再試行してください。'
+    );
+  }
+
+  const updatedInvoice = await prisma.invoice.findUnique({
+    where: { id: invoiceId },
+    include: {
+      client: true,
+      items: {
+        orderBy: { sortOrder: 'asc' },
+      },
+      quote: {
+        select: {
+          id: true,
+          quoteNumber: true,
+          issueDate: true,
+          status: true,
+        },
+      },
+    },
+  });
+
+  if (!updatedInvoice) {
+    throw new NotFoundError('請求書が見つかりません');
+  }
+
+  return updatedInvoice as InvoiceWithRelations;
+}
+
+/**
+ * 請求書のステータスを更新
+ */
+export async function updateInvoiceStatus(
+  invoiceId: string,
+  companyId: string,
+  newStatus: InvoiceStatus,
+  paymentDate?: Date
+): Promise<InvoiceWithRelations> {
+  return await prisma.$transaction(async (tx) => {
+    // 請求書の存在確認
+    const existingInvoice = await tx.invoice.findFirst({
+      where: {
+        id: invoiceId,
+        companyId,
+        deletedAt: null,
+      },
+      include: {
+        items: true,
+      },
+    });
+
+    if (!existingInvoice) {
+      throw new NotFoundError('請求書が見つかりません');
+    }
+
+    // ステータス遷移の妥当性チェック
+    if (!isValidStatusTransition(existingInvoice.status, newStatus)) {
+      throw httpError(400, '無効なステータス遷移です');
+    }
+
+    // 品目が必要な遷移の場合のチェック
+    if (requiresItemsForTransition(existingInvoice.status, newStatus)) {
+      if (!existingInvoice.items || existingInvoice.items.length === 0) {
+        throw httpError(400, 'ステータス変更には品目の登録が必要です');
+      }
+
+      // 品目の妥当性チェック
+      for (let i = 0; i < existingInvoice.items.length; i++) {
+        const item = existingInvoice.items[i];
+        const qty = Number(item.quantity);
+        const price = Number(item.unitPrice);
+        const discount = Number(item.discountAmount);
+
+        if (qty <= 0) {
+          throw new Error(`品目${i + 1}行目: 数量は正の数である必要があります`);
+        }
+        if (price < 0) {
+          throw new Error(`品目${i + 1}行目: 単価は0以上である必要があります`);
+        }
+        if (discount > price * qty) {
+          throw new Error(
+            `品目${i + 1}行目: 割引額が品目合計金額を超えています`
+          );
+        }
+      }
+    }
+
+    // 支払日が必要な遷移の場合のチェック
+    if (newStatus === 'PAID' && !paymentDate) {
+      throw httpError(400, '支払済みステータスには支払日が必要です');
+    }
+
+    const updateData: {
+      status: InvoiceStatus;
+      invoiceNumber?: string;
+      paymentDate?: Date | null;
+    } = {
+      status: newStatus,
+      paymentDate: newStatus === 'PAID' ? paymentDate || new Date() : null,
+    };
+
+    // 番号生成が必要な場合
+    if (
+      requiresNumberGenerationForTransition(existingInvoice.status, newStatus)
+    ) {
+      // 会社情報取得とシーケンス更新
+      const company = await tx.company.update({
+        where: { id: companyId },
+        data: {
+          invoiceNumberSeq: {
+            increment: 1,
+          },
+        },
+      });
+
+      // 請求書番号生成
+      const invoiceNumber = generateInvoiceNumber(company.invoiceNumberSeq);
+      updateData.invoiceNumber = invoiceNumber;
+    }
+
+    // 請求書更新
+    const updatedInvoice = await tx.invoice.update({
+      where: { id: invoiceId },
+      data: updateData,
+      include: {
+        client: true,
+        items: {
+          orderBy: { sortOrder: 'asc' },
+        },
+        quote: {
+          select: {
+            id: true,
+            quoteNumber: true,
+            issueDate: true,
+            status: true,
+          },
+        },
+      },
+    });
+
+    return updatedInvoice as InvoiceWithRelations;
+  });
+}
+
+/**
+ * 支払情報を更新
+ */
+export async function updatePaymentInfo(
+  invoiceId: string,
+  companyId: string,
+  data: UpdatePaymentData
+): Promise<InvoiceWithRelations> {
+  // 請求書の存在確認
+  const existingInvoice = await prisma.invoice.findFirst({
+    where: {
+      id: invoiceId,
+      companyId,
+      deletedAt: null,
+    },
+  });
+
+  if (!existingInvoice) {
+    throw new NotFoundError('請求書が見つかりません');
+  }
+
+  // ステータス遷移の妥当性チェック
+  if (!isValidStatusTransition(existingInvoice.status, data.status)) {
+    throw httpError(400, '無効なステータス遷移です');
+  }
+
+  // 支払済みステータスには支払日が必要
+  if (data.status === 'PAID' && !data.paymentDate) {
+    throw httpError(400, '支払済みステータスには支払日が必要です');
+  }
+
+  const updatedInvoice = await prisma.invoice.update({
+    where: { id: invoiceId },
+    data: {
+      status: data.status,
+      paymentDate: data.paymentDate,
+    },
+    include: {
+      client: true,
+      items: {
+        orderBy: { sortOrder: 'asc' },
+      },
+      quote: {
+        select: {
+          id: true,
+          quoteNumber: true,
+          issueDate: true,
+          status: true,
+        },
+      },
+    },
+  });
+
+  return updatedInvoice as InvoiceWithRelations;
+}
+
+/**
+ * 期限超過請求書の自動ステータス更新
+ */
+export async function updateOverdueInvoices(
+  companyId: string
+): Promise<number> {
+  const today = new Date();
+  today.setHours(23, 59, 59, 999); // 今日の終わりまで
+
+  const result = await prisma.invoice.updateMany({
+    where: {
+      companyId,
+      status: 'SENT',
+      dueDate: {
+        lt: today,
+      },
+      paymentDate: null,
+      deletedAt: null,
+    },
+    data: {
+      status: 'OVERDUE',
+    },
+  });
+
+  return result.count;
+}
+
+/**
+ * 請求書を削除（論理削除）
+ */
+export async function deleteInvoice(
+  invoiceId: string,
+  companyId: string
+): Promise<void> {
+  const existingInvoice = await prisma.invoice.findFirst({
+    where: {
+      id: invoiceId,
+      companyId,
+      deletedAt: null,
+    },
+  });
+
+  if (!existingInvoice) {
+    throw new NotFoundError('請求書が見つかりません');
+  }
+
+  await prisma.invoice.update({
+    where: { id: invoiceId },
+    data: { deletedAt: new Date() },
+  });
+}
+
+/**
+ * 請求書一覧を取得
+ */
+export async function getInvoices(
+  companyId: string,
+  where: InvoiceFilterConditions,
+  orderBy: Prisma.InvoiceOrderByWithRelationInput,
+  include: InvoiceIncludeConfig,
+  pagination: { skip: number; take: number }
+): Promise<{ invoices: InvoiceWithRelations[]; total: number }> {
+  const [invoices, total] = await Promise.all([
+    prisma.invoice.findMany({
+      where,
+      orderBy,
+      include,
+      skip: pagination.skip,
+      take: pagination.take,
+    }),
+    prisma.invoice.count({ where }),
+  ]);
+
+  return { invoices: invoices as InvoiceWithRelations[], total };
+}
+
+/**
+ * 請求書を取得
+ */
+export async function getInvoice(
+  invoiceId: string,
+  companyId: string,
+  include: InvoiceIncludeConfig = {}
+): Promise<InvoiceWithRelations | null> {
+  const invoice = await prisma.invoice.findFirst({
+    where: {
+      id: invoiceId,
+      companyId,
+      deletedAt: null,
+    },
+    include,
+  });
+
+  return invoice as InvoiceWithRelations | null;
+}
+
+/**
+ * 品目を作成
+ */
+export async function createInvoiceItem(
+  invoiceId: string,
+  companyId: string,
+  data: InvoiceItemData
+): Promise<PrismaInvoiceItem> {
+  // 請求書の存在確認
+  const invoice = await prisma.invoice.findFirst({
+    where: {
+      id: invoiceId,
+      companyId,
+      deletedAt: null,
+    },
+  });
+
+  if (!invoice) {
+    throw new NotFoundError('請求書が見つかりません');
+  }
+
+  // 並び順の自動決定（未指定または0のとき）
+  let sortOrder = data.sortOrder;
+  if (sortOrder === undefined || sortOrder === 0) {
+    const next = await getNextSortOrder(invoiceId);
+    sortOrder = next;
+  }
+
+  const item = await prisma.invoiceItem.create({
+    data: {
+      invoiceId,
+      ...data,
+      sortOrder,
+    },
+  });
+
+  return item as PrismaInvoiceItem;
+}
+
+/**
+ * 品目を更新
+ */
+export async function updateInvoiceItem(
+  itemId: string,
+  invoiceId: string,
+  companyId: string,
+  data: InvoiceItemUpdateData
+): Promise<PrismaInvoiceItem> {
+  // 品目の存在確認
+  const existingItem = await prisma.invoiceItem.findFirst({
+    where: {
+      id: itemId,
+      invoice: {
+        id: invoiceId,
+        companyId,
+        deletedAt: null,
+      },
+    },
+  });
+
+  if (!existingItem) {
+    throw new NotFoundError('品目が見つかりません');
+  }
+
+  // 既存値を考慮した整合性チェック（数量・単価・割引の合計超過防止）
+  {
+    const effectiveQuantity =
+      data.quantity !== undefined
+        ? Number(data.quantity)
+        : Number(existingItem.quantity);
+    const effectiveUnitPrice =
+      data.unitPrice !== undefined
+        ? Number(data.unitPrice)
+        : Number(existingItem.unitPrice);
+    const effectiveDiscount =
+      data.discountAmount !== undefined
+        ? Number(data.discountAmount)
+        : Number(existingItem.discountAmount);
+
+    if (effectiveQuantity <= 0) {
+      throw httpError(400, '数量は正の数である必要があります');
+    }
+    if (effectiveUnitPrice < 0) {
+      throw httpError(400, '単価は0以上である必要があります');
+    }
+    if (effectiveDiscount < 0) {
+      throw httpError(400, '割引額は0以上である必要があります');
+    }
+    if (effectiveDiscount > effectiveUnitPrice * effectiveQuantity) {
+      throw httpError(400, '割引額は品目合計金額を超えることはできません');
+    }
+  }
+
+  // 楽観ロック: updatedAt 一致条件
+  const { updatedAt, ...updateData } = data;
+  const result = await prisma.invoiceItem.updateMany({
+    where: {
+      id: itemId,
+      invoiceId,
+      invoice: { companyId, deletedAt: null },
+      updatedAt,
+    },
+    data: updateData,
+  });
+  if (result.count === 0) {
+    throw new ConflictError(
+      '更新競合が発生しました。最新の状態を取得してから再試行してください。'
+    );
+  }
+  const item = await prisma.invoiceItem.findUnique({ where: { id: itemId } });
+  if (!item) throw new NotFoundError('品目が見つかりません');
+
+  return item as PrismaInvoiceItem;
+}
+
+/**
+ * 品目を削除
+ */
+export async function deleteInvoiceItem(
+  itemId: string,
+  invoiceId: string,
+  companyId: string
+): Promise<void> {
+  const existingItem = await prisma.invoiceItem.findFirst({
+    where: {
+      id: itemId,
+      invoice: {
+        id: invoiceId,
+        companyId,
+        deletedAt: null,
+      },
+    },
+  });
+
+  if (!existingItem) {
+    throw new NotFoundError('品目が見つかりません');
+  }
+
+  await prisma.invoiceItem.delete({
+    where: { id: itemId },
+  });
+}
+
+/**
+ * 品目一覧を取得
+ */
+export async function getInvoiceItems(
+  invoiceId: string,
+  companyId: string
+): Promise<PrismaInvoiceItem[]> {
+  const items = await prisma.invoiceItem.findMany({
+    where: {
+      invoice: {
+        id: invoiceId,
+        companyId,
+        deletedAt: null,
+      },
+    },
+    orderBy: { sortOrder: 'asc' },
+  });
+
+  return items as PrismaInvoiceItem[];
+}
+
+/**
+ * 品目を取得
+ */
+export async function getInvoiceItem(
+  itemId: string,
+  invoiceId: string,
+  companyId: string
+): Promise<PrismaInvoiceItem | null> {
+  const item = await prisma.invoiceItem.findFirst({
+    where: {
+      id: itemId,
+      invoice: {
+        id: invoiceId,
+        companyId,
+        deletedAt: null,
+      },
+    },
+  });
+
+  return item as PrismaInvoiceItem | null;
+}
+
+/**
+ * 品目の並び順を一括更新
+ */
+export async function reorderInvoiceItems(
+  invoiceId: string,
+  companyId: string,
+  data: ReorderInvoiceItemsData
+): Promise<PrismaInvoiceItem[]> {
+  return await prisma.$transaction(async (tx) => {
+    // 請求書の存在確認
+    const invoice = await tx.invoice.findFirst({
+      where: {
+        id: invoiceId,
+        companyId,
+        deletedAt: null,
+      },
+    });
+
+    if (!invoice) {
+      throw new NotFoundError('請求書が見つかりません');
+    }
+
+    // 並び順を正規化
+    const normalizedItems = normalizeSortOrder(data.items);
+
+    // 一括更新
+    for (const item of normalizedItems) {
+      await tx.invoiceItem.updateMany({
+        where: {
+          id: item.id,
+          invoiceId,
+          invoice: { companyId, deletedAt: null },
+          updatedAt: data.items.find((i) => i.id === item.id)?.updatedAt,
+        },
+        data: {
+          sortOrder: item.sortOrder,
+        },
+      });
+    }
+
+    // 更新後の品目一覧を取得
+    const updatedItems = await tx.invoiceItem.findMany({
+      where: {
+        invoice: {
+          id: invoiceId,
+          companyId,
+          deletedAt: null,
+        },
+      },
+      orderBy: { sortOrder: 'asc' },
+    });
+
+    return updatedItems as PrismaInvoiceItem[];
+  });
+}
+
+/**
+ * 税計算を実行
+ */
+export async function calculateInvoiceTax(
+  invoiceId: string,
+  companyId: string
+): Promise<TaxCalculationResult> {
+  // 請求書と会社情報を取得
+  const [invoice, company] = await Promise.all([
+    prisma.invoice.findFirst({
+      where: {
+        id: invoiceId,
+        companyId,
+        deletedAt: null,
+      },
+      include: {
+        items: true,
+      },
+    }),
+    prisma.company.findUnique({
+      where: { id: companyId },
+      select: {
+        standardTaxRate: true,
+        reducedTaxRate: true,
+        priceIncludesTax: true,
+      },
+    }),
+  ]);
+
+  if (!invoice) {
+    throw new NotFoundError('請求書が見つかりません');
+  }
+
+  if (!company) {
+    throw new NotFoundError('会社情報が見つかりません');
+  }
+
+  return calculateTax(
+    invoice.items.map((item) => ({
+      ...item,
+      quantity: Number(item.quantity),
+      unitPrice: Number(item.unitPrice),
+      discountAmount: Number(item.discountAmount),
+      taxRate: item.taxRate ? Number(item.taxRate) : null,
+    })),
+    {
+      ...company,
+      standardTaxRate: Number(company.standardTaxRate),
+      reducedTaxRate: Number(company.reducedTaxRate),
+    }
+  );
+}
+
+/**
+ * 次の並び順を取得
+ */
+async function getNextSortOrder(invoiceId: string): Promise<number> {
+  const lastItem = await prisma.invoiceItem.findFirst({
+    where: { invoiceId },
+    orderBy: { sortOrder: 'desc' },
+    select: { sortOrder: true },
+  });
+
+  return (lastItem?.sortOrder ?? -1) + 1;
+}

--- a/lib/domains/invoices/types.ts
+++ b/lib/domains/invoices/types.ts
@@ -60,8 +60,8 @@ export interface InvoiceItem {
   unit: string | null;
   sku: string | null;
   sortOrder: number;
-  createdAt: Date;
-  updatedAt: Date;
+  createdAt: string;
+  updatedAt: string;
 }
 
 /**
@@ -338,8 +338,8 @@ export function convertPrismaInvoiceItemToInvoiceItem(
     unit: prismaItem.unit,
     sku: prismaItem.sku,
     sortOrder: prismaItem.sortOrder,
-    createdAt: prismaItem.createdAt,
-    updatedAt: prismaItem.updatedAt,
+    createdAt: prismaItem.createdAt.toISOString(),
+    updatedAt: prismaItem.updatedAt.toISOString(),
   } satisfies InvoiceItem;
 }
 

--- a/lib/domains/invoices/types.ts
+++ b/lib/domains/invoices/types.ts
@@ -1,0 +1,412 @@
+import {
+  InvoiceStatus as PrismaInvoiceStatus,
+  Invoice as PrismaInvoice,
+  InvoiceItem as PrismaInvoiceItem,
+  Client as PrismaClientModel,
+  Quote as PrismaQuote,
+} from '@prisma/client';
+
+export type InvoiceStatus = PrismaInvoiceStatus;
+
+import { Client } from '@/lib/shared/types';
+
+import { InvoiceItemData } from './schemas';
+
+/**
+ * サービス層で使用するPrisma型（Decimal型を含む）
+ */
+export type InvoiceWithRelations = PrismaInvoice & {
+  client?: PrismaClientModel;
+  items?: PrismaInvoiceItem[];
+  quote?: PrismaQuote;
+};
+
+/**
+ * API層で使用するドメイン型（number型に変換済み）
+ */
+export interface Invoice {
+  id: string;
+  companyId: string;
+  clientId: string;
+  quoteId: string | null;
+  invoiceNumber: string;
+  issueDate: string;
+  dueDate: string | null;
+  status: InvoiceStatus;
+  notes: string | null;
+  paymentDate: string | null;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string | null;
+  client?: Client;
+  items?: InvoiceItem[];
+  quote?: {
+    id: string;
+    quoteNumber: string;
+    issueDate: string;
+    status: string;
+  };
+}
+
+export interface InvoiceItem {
+  id: string;
+  invoiceId: string;
+  description: string;
+  quantity: number;
+  unitPrice: number;
+  taxCategory: 'STANDARD' | 'REDUCED' | 'EXEMPT' | 'NON_TAX';
+  taxRate: number | null;
+  discountAmount: number;
+  unit: string | null;
+  sku: string | null;
+  sortOrder: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * 会社型定義（税計算・番号採番用）
+ */
+export interface Company {
+  id: string;
+  standardTaxRate: number;
+  reducedTaxRate: number;
+  priceIncludesTax: boolean;
+  invoiceNumberSeq: number;
+}
+
+/**
+ * 請求書一覧レスポンス型
+ */
+export interface InvoicesListResponse {
+  data: Invoice[];
+  pagination: {
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+  };
+}
+
+/**
+ * 請求書検索レスポンス型
+ */
+export interface InvoicesSearchResponse {
+  data: Invoice[];
+  total: number;
+}
+
+/**
+ * バルク処理アクション型
+ */
+export type BulkAction = 'create' | 'update' | 'delete';
+
+/**
+ * バルク処理品目型
+ */
+export type BulkInvoiceItem =
+  | { action: 'create'; data: InvoiceItemData }
+  | { action: 'update'; id: string; data: InvoiceItemData }
+  | { action: 'delete'; id: string };
+
+/**
+ * CSVインポート結果型
+ */
+export interface CsvImportResult {
+  success: boolean;
+  imported: number;
+  errors: Array<{
+    row: number;
+    error: string;
+  }>;
+}
+
+/**
+ * 税計算結果型
+ */
+export interface TaxCalculationResult {
+  subtotalAmount: number;
+  taxAmountStandard: number;
+  taxAmountReduced: number;
+  taxAmountExempt: number;
+  totalAmount: number;
+}
+
+/**
+ * 請求書番号生成オプション型
+ */
+export interface InvoiceNumberGenerationOptions {
+  companyId: string;
+  format?: string; // デフォルト: "I{seq:04d}"
+}
+
+/**
+ * 見積書から請求書作成結果型
+ */
+export interface CreateInvoiceFromQuoteResult {
+  invoice: InvoiceWithRelations;
+  duplicatedItemsCount: number;
+  selectedItemsCount: number;
+}
+
+/**
+ * 支払情報型
+ */
+export interface PaymentInfo {
+  status: InvoiceStatus;
+  paymentDate: string | null;
+  dueDate: string | null;
+  daysOverdue?: number;
+}
+
+/**
+ * エラーレスポンス型
+ */
+export interface ApiErrorResponse {
+  error: string;
+  message: string;
+  details?: unknown;
+}
+
+/**
+ * 成功レスポンス型
+ */
+export interface ApiSuccessResponse<T = unknown> {
+  data: T;
+  message?: string;
+}
+
+/**
+ * ソートオプション型
+ */
+export type InvoiceSortOption =
+  | 'issueDate_asc'
+  | 'issueDate_desc'
+  | 'dueDate_asc'
+  | 'dueDate_desc'
+  | 'createdAt_asc'
+  | 'createdAt_desc'
+  | 'invoiceNumber_asc'
+  | 'invoiceNumber_desc';
+
+/**
+ * include オプション型
+ */
+export type InvoiceIncludeOption = 'client' | 'items' | 'quote';
+
+/**
+ * ステータス遷移ルール型
+ */
+export interface StatusTransitionRule {
+  from: InvoiceStatus;
+  to: InvoiceStatus[];
+  requiresItems?: boolean;
+  requiresNumberGeneration?: boolean;
+  requiresPaymentDate?: boolean;
+}
+
+/**
+ * Prismaインクルード設定型
+ */
+export interface InvoiceIncludeConfig {
+  client?: boolean;
+  items?:
+    | boolean
+    | {
+        orderBy?: {
+          sortOrder?: 'asc' | 'desc';
+        };
+      };
+  quote?:
+    | boolean
+    | {
+        select?: {
+          id: boolean;
+          quoteNumber: boolean;
+          issueDate: boolean;
+          status: boolean;
+        };
+      };
+}
+
+/**
+ * 請求書フィルター条件型
+ */
+export interface InvoiceFilterConditions {
+  companyId: string;
+  deletedAt?: null;
+  status?: InvoiceStatus;
+  clientId?: string;
+  quoteId?: string;
+  issueDate?: {
+    gte?: Date;
+    lte?: Date;
+  };
+  dueDate?: {
+    gte?: Date;
+    lte?: Date;
+  };
+  OR?: Array<{
+    invoiceNumber?: {
+      contains: string;
+      mode: 'insensitive';
+    };
+    notes?: {
+      contains: string;
+      mode: 'insensitive';
+    };
+    client?: {
+      name?: {
+        contains: string;
+        mode: 'insensitive';
+      };
+    };
+  }>;
+}
+
+/**
+ * 支払期限オーバー判定結果型
+ */
+export interface OverdueCheckResult {
+  isOverdue: boolean;
+  daysOverdue: number;
+  shouldUpdateStatus: boolean;
+}
+
+/**
+ * Prisma型からドメイン型への変換関数
+ */
+export function convertPrismaInvoiceToInvoice(
+  prismaInvoice: InvoiceWithRelations
+): Invoice {
+  return {
+    id: prismaInvoice.id,
+    companyId: prismaInvoice.companyId,
+    clientId: prismaInvoice.clientId,
+    quoteId: prismaInvoice.quoteId,
+    invoiceNumber: prismaInvoice.invoiceNumber,
+    issueDate: prismaInvoice.issueDate.toISOString(),
+    dueDate: prismaInvoice.dueDate?.toISOString() ?? null,
+    status: prismaInvoice.status,
+    notes: prismaInvoice.notes,
+    paymentDate: prismaInvoice.paymentDate?.toISOString() ?? null,
+    createdAt: prismaInvoice.createdAt.toISOString(),
+    updatedAt: prismaInvoice.updatedAt.toISOString(),
+    deletedAt: prismaInvoice.deletedAt?.toISOString() ?? null,
+    client: prismaInvoice.client
+      ? {
+          id: prismaInvoice.client.id,
+          companyId: prismaInvoice.client.companyId,
+          name: prismaInvoice.client.name,
+          contactName: prismaInvoice.client.contactName ?? undefined,
+          contactEmail: prismaInvoice.client.contactEmail ?? undefined,
+          address: prismaInvoice.client.address ?? undefined,
+          phone: prismaInvoice.client.phone ?? undefined,
+          createdAt: prismaInvoice.client.createdAt.toISOString(),
+          updatedAt: prismaInvoice.client.updatedAt.toISOString(),
+          deletedAt: prismaInvoice.client.deletedAt?.toISOString() ?? undefined,
+        }
+      : undefined,
+    // items配列が存在する場合は変換、存在しない場合はundefined
+    items: prismaInvoice.items
+      ? prismaInvoice.items.map(convertPrismaInvoiceItemToInvoiceItem)
+      : undefined,
+    // quote情報が存在する場合は変換
+    quote: prismaInvoice.quote
+      ? {
+          id: prismaInvoice.quote.id,
+          quoteNumber: prismaInvoice.quote.quoteNumber,
+          issueDate: prismaInvoice.quote.issueDate.toISOString(),
+          status: prismaInvoice.quote.status,
+        }
+      : undefined,
+  } satisfies Invoice;
+}
+
+export function convertPrismaInvoiceItemToInvoiceItem(
+  prismaItem: PrismaInvoiceItem
+): InvoiceItem {
+  return {
+    id: prismaItem.id,
+    invoiceId: prismaItem.invoiceId,
+    description: prismaItem.description,
+    quantity: Number(prismaItem.quantity),
+    unitPrice: Number(prismaItem.unitPrice),
+    taxCategory: prismaItem.taxCategory,
+    taxRate: prismaItem.taxRate === null ? null : Number(prismaItem.taxRate),
+    discountAmount: Number(prismaItem.discountAmount),
+    unit: prismaItem.unit,
+    sku: prismaItem.sku,
+    sortOrder: prismaItem.sortOrder,
+    createdAt: prismaItem.createdAt,
+    updatedAt: prismaItem.updatedAt,
+  } satisfies InvoiceItem;
+}
+
+/**
+ * 支払期限オーバーチェック関数
+ */
+export function checkOverdueStatus(
+  invoice: Pick<Invoice, 'dueDate' | 'status' | 'paymentDate'>
+): OverdueCheckResult {
+  if (!invoice.dueDate || invoice.status === 'PAID' || invoice.paymentDate) {
+    return {
+      isOverdue: false,
+      daysOverdue: 0,
+      shouldUpdateStatus: false,
+    };
+  }
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0); // 時刻を0時に設定
+  const dueDate = new Date(invoice.dueDate);
+  dueDate.setHours(0, 0, 0, 0);
+
+  const daysOverdue = Math.floor(
+    (today.getTime() - dueDate.getTime()) / (1000 * 60 * 60 * 24)
+  );
+
+  const isOverdue = daysOverdue > 0;
+  const shouldUpdateStatus = isOverdue && invoice.status === 'SENT';
+
+  return {
+    isOverdue,
+    daysOverdue: Math.max(0, daysOverdue),
+    shouldUpdateStatus,
+  };
+}
+
+/**
+ * UI層で使用するフォーム型制約（コンポーネント用）
+ * React Hook Form の Control<T> のジェネリクス制約として使用
+ */
+export interface InvoiceBasicsShape {
+  clientId: string;
+  clientName?: string;
+  issueDate: Date;
+  dueDate?: Date;
+  notes?: string;
+  quoteId?: string;
+}
+
+/**
+ * 支払管理フォーム型制約
+ */
+export interface PaymentFormShape {
+  status: InvoiceStatus;
+  paymentDate?: Date;
+}
+
+/**
+ * エクスポート型定義（API層用）
+ */
+export type {
+  InvoiceData,
+  InvoiceUpdateData,
+  InvoiceItemData,
+  InvoiceItemUpdateData,
+  BulkInvoiceItemsData,
+  InvoiceSearchParams,
+  CreateInvoiceFromQuoteData,
+  UpdatePaymentData,
+} from './schemas';

--- a/lib/domains/invoices/utils.ts
+++ b/lib/domains/invoices/utils.ts
@@ -529,13 +529,25 @@ export function preprocessInvoiceFormData(
 
   // 日付フィールドの処理
   if (processed.issueDate && typeof processed.issueDate === 'string') {
-    processed.issueDate = new Date(processed.issueDate);
+    const date = new Date(processed.issueDate);
+    if (isNaN(date.getTime())) {
+      throw new Error('無効な発行日が指定されました');
+    }
+    processed.issueDate = date;
   }
   if (processed.dueDate && typeof processed.dueDate === 'string') {
-    processed.dueDate = new Date(processed.dueDate);
+    const date = new Date(processed.dueDate);
+    if (isNaN(date.getTime())) {
+      throw new Error('無効な支払期限が指定されました');
+    }
+    processed.dueDate = date;
   }
   if (processed.paymentDate && typeof processed.paymentDate === 'string') {
-    processed.paymentDate = new Date(processed.paymentDate);
+    const date = new Date(processed.paymentDate);
+    if (isNaN(date.getTime())) {
+      throw new Error('無効な支払日が指定されました');
+    }
+    processed.paymentDate = date;
   }
 
   return processed;

--- a/lib/domains/invoices/utils.ts
+++ b/lib/domains/invoices/utils.ts
@@ -1,0 +1,542 @@
+import { Prisma, InvoiceStatus } from '@prisma/client';
+import Papa from 'papaparse';
+
+import type {
+  InvoiceFilterConditions,
+  InvoiceIncludeConfig,
+  InvoiceIncludeOption,
+  InvoiceSortOption,
+  TaxCalculationResult,
+  InvoiceItem,
+  Company,
+  StatusTransitionRule,
+  OverdueCheckResult,
+} from './types';
+
+/**
+ * 請求書ドメイン共通ユーティリティ
+ */
+
+// 検索対象フィールド
+export const INVOICE_SEARCH_FIELDS = [
+  'invoiceNumber',
+  'notes',
+  'client.name',
+] as const;
+
+// ソートマッピング
+export const INVOICE_SORT_MAPPING: Record<
+  InvoiceSortOption,
+  Prisma.InvoiceOrderByWithRelationInput
+> = {
+  issueDate_asc: { issueDate: 'asc' },
+  issueDate_desc: { issueDate: 'desc' },
+  dueDate_asc: { dueDate: 'asc' },
+  dueDate_desc: { dueDate: 'desc' },
+  createdAt_asc: { createdAt: 'asc' },
+  createdAt_desc: { createdAt: 'desc' },
+  invoiceNumber_asc: { invoiceNumber: 'asc' },
+  invoiceNumber_desc: { invoiceNumber: 'desc' },
+};
+
+// includeオプション
+export const INVOICE_INCLUDE_OPTIONS = ['client', 'items', 'quote'] as const;
+
+// ステータス遷移ルール
+export const STATUS_TRANSITION_RULES: StatusTransitionRule[] = [
+  {
+    from: 'DRAFT',
+    to: ['SENT'],
+    requiresItems: true,
+    requiresNumberGeneration: true,
+  },
+  {
+    from: 'SENT',
+    to: ['PAID', 'OVERDUE'],
+    requiresItems: false,
+    requiresNumberGeneration: false,
+    requiresPaymentDate: false, // PAID遷移時のみ必要（別途チェック）
+  },
+  {
+    from: 'OVERDUE',
+    to: ['PAID'],
+    requiresItems: false,
+    requiresNumberGeneration: false,
+    requiresPaymentDate: true,
+  },
+  {
+    from: 'PAID',
+    to: [], // 支払済みからの遷移は基本的になし
+    requiresItems: false,
+    requiresNumberGeneration: false,
+  },
+];
+
+/**
+ * 関連データ取得設定を構築
+ */
+export function buildIncludeRelations(
+  include: InvoiceIncludeOption[]
+): InvoiceIncludeConfig {
+  const config: InvoiceIncludeConfig = {};
+
+  if (include.includes('client')) {
+    config.client = true;
+  }
+
+  if (include.includes('items')) {
+    config.items = {
+      orderBy: {
+        sortOrder: 'asc',
+      },
+    };
+  }
+
+  if (include.includes('quote')) {
+    config.quote = {
+      select: {
+        id: true,
+        quoteNumber: true,
+        issueDate: true,
+        status: true,
+      },
+    };
+  }
+
+  return config;
+}
+
+/**
+ * 請求書検索WHERE条件を構築
+ */
+export function buildInvoiceSearchWhere(
+  companyId: string,
+  options: {
+    query?: string;
+    status?: InvoiceStatus;
+    clientId?: string;
+    quoteId?: string;
+    dateFrom?: Date;
+    dateTo?: Date;
+    dueDateFrom?: Date;
+    dueDateTo?: Date;
+  } = {}
+): InvoiceFilterConditions {
+  const where: InvoiceFilterConditions = {
+    companyId,
+    deletedAt: null,
+  };
+
+  // ステータスフィルター
+  if (options.status) {
+    where.status = options.status;
+  }
+
+  // クライアントフィルター
+  if (options.clientId) {
+    where.clientId = options.clientId;
+  }
+
+  // 見積書フィルター
+  if (options.quoteId) {
+    where.quoteId = options.quoteId;
+  }
+
+  // 発行日範囲フィルター
+  if (options.dateFrom || options.dateTo) {
+    where.issueDate = {};
+    if (options.dateFrom) {
+      where.issueDate.gte = options.dateFrom;
+    }
+    if (options.dateTo) {
+      where.issueDate.lte = options.dateTo;
+    }
+  }
+
+  // 支払期限範囲フィルター
+  if (options.dueDateFrom || options.dueDateTo) {
+    where.dueDate = {};
+    if (options.dueDateFrom) {
+      where.dueDate.gte = options.dueDateFrom;
+    }
+    if (options.dueDateTo) {
+      where.dueDate.lte = options.dueDateTo;
+    }
+  }
+
+  // テキスト検索
+  if (options.query) {
+    where.OR = [
+      {
+        invoiceNumber: {
+          contains: options.query,
+          mode: 'insensitive',
+        },
+      },
+      {
+        notes: {
+          contains: options.query,
+          mode: 'insensitive',
+        },
+      },
+      {
+        client: {
+          name: {
+            contains: options.query,
+            mode: 'insensitive',
+          },
+        },
+      },
+    ];
+  }
+
+  return where;
+}
+
+/**
+ * ソート条件を構築
+ */
+export function buildOrderBy(
+  sort: InvoiceSortOption
+): Prisma.InvoiceOrderByWithRelationInput {
+  return INVOICE_SORT_MAPPING[sort] ?? { createdAt: 'desc' };
+}
+
+/**
+ * 請求書番号を生成
+ */
+export function generateInvoiceNumber(
+  sequence: number,
+  format = 'I{seq:04d}'
+): string {
+  return format.replace('{seq:04d}', sequence.toString().padStart(4, '0'));
+}
+
+/**
+ * ステータス遷移が有効かチェック
+ */
+export function isValidStatusTransition(
+  from: InvoiceStatus,
+  to: InvoiceStatus
+): boolean {
+  const rule = STATUS_TRANSITION_RULES.find((r) => r.from === from);
+  return rule ? rule.to.includes(to) : false;
+}
+
+/**
+ * ステータス遷移に品目が必要かチェック
+ */
+export function requiresItemsForTransition(
+  from: InvoiceStatus,
+  to: InvoiceStatus
+): boolean {
+  const rule = STATUS_TRANSITION_RULES.find(
+    (r) => r.from === from && r.to.includes(to)
+  );
+  return rule ? (rule.requiresItems ?? false) : false;
+}
+
+/**
+ * ステータス遷移に番号生成が必要かチェック
+ */
+export function requiresNumberGenerationForTransition(
+  from: InvoiceStatus,
+  to: InvoiceStatus
+): boolean {
+  const rule = STATUS_TRANSITION_RULES.find(
+    (r) => r.from === from && r.to.includes(to)
+  );
+  return rule ? (rule.requiresNumberGeneration ?? false) : false;
+}
+
+/**
+ * ステータス遷移に支払日が必要かチェック
+ */
+export function requiresPaymentDateForTransition(
+  from: InvoiceStatus,
+  to: InvoiceStatus
+): boolean {
+  const rule = STATUS_TRANSITION_RULES.find(
+    (r) => r.from === from && r.to.includes(to)
+  );
+  return rule ? (rule.requiresPaymentDate ?? false) : false;
+}
+
+/**
+ * 支払期限オーバーの自動ステータス更新が必要かチェック
+ */
+export function shouldAutoUpdateOverdueStatus(
+  invoiceStatus: InvoiceStatus,
+  dueDate: Date | null,
+  paymentDate: Date | null
+): OverdueCheckResult {
+  if (!dueDate || invoiceStatus === 'PAID' || paymentDate) {
+    return {
+      isOverdue: false,
+      daysOverdue: 0,
+      shouldUpdateStatus: false,
+    };
+  }
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0); // 時刻を0時に設定
+  const dueDateOnly = new Date(dueDate);
+  dueDateOnly.setHours(0, 0, 0, 0);
+
+  const daysOverdue = Math.floor(
+    (today.getTime() - dueDateOnly.getTime()) / (1000 * 60 * 60 * 24)
+  );
+
+  const isOverdue = daysOverdue > 0;
+  const shouldUpdateStatus = isOverdue && invoiceStatus === 'SENT';
+
+  return {
+    isOverdue,
+    daysOverdue: Math.max(0, daysOverdue),
+    shouldUpdateStatus,
+  };
+}
+
+/**
+ * 支払期限を自動計算（発行日から指定日数後）
+ */
+export function calculateDueDate(
+  issueDate: Date,
+  paymentTermDays: number = 30
+): Date {
+  const dueDate = new Date(issueDate);
+  dueDate.setDate(dueDate.getDate() + paymentTermDays);
+  return dueDate;
+}
+
+/**
+ * 税計算を実行（見積書と同じロジックを再利用）
+ */
+export function calculateTax(
+  items: InvoiceItem[],
+  company: Pick<
+    Company,
+    'standardTaxRate' | 'reducedTaxRate' | 'priceIncludesTax'
+  >
+): TaxCalculationResult {
+  let subtotalAmount = 0;
+  let taxAmountStandard = 0;
+  let taxAmountReduced = 0;
+  let taxAmountExempt = 0;
+
+  items.forEach((item) => {
+    // 品目小計（割引後）
+    const lineNet = item.unitPrice * item.quantity - item.discountAmount;
+    subtotalAmount += lineNet;
+
+    // 税率決定
+    let effectiveTaxRate = 0;
+    if (item.taxRate !== null) {
+      // 個別税率が指定されている場合
+      effectiveTaxRate = item.taxRate;
+    } else {
+      // 税区分に基づく税率
+      switch (item.taxCategory) {
+        case 'STANDARD':
+          effectiveTaxRate = company.standardTaxRate;
+          break;
+        case 'REDUCED':
+          effectiveTaxRate = company.reducedTaxRate;
+          break;
+        case 'EXEMPT':
+        case 'NON_TAX':
+          effectiveTaxRate = 0;
+          break;
+      }
+    }
+
+    // 税額計算（四捨五入）
+    const lineTax = Math.round((lineNet * effectiveTaxRate) / 100);
+
+    // 税率別に集計
+    if (
+      item.taxCategory === 'STANDARD' ||
+      (item.taxRate !== null && item.taxRate === company.standardTaxRate)
+    ) {
+      taxAmountStandard += lineTax;
+    } else if (
+      item.taxCategory === 'REDUCED' ||
+      (item.taxRate !== null && item.taxRate === company.reducedTaxRate)
+    ) {
+      taxAmountReduced += lineTax;
+    } else if (
+      item.taxCategory === 'EXEMPT' ||
+      item.taxCategory === 'NON_TAX'
+    ) {
+      taxAmountExempt += lineTax;
+    } else {
+      // その他の個別税率は標準税額に分類
+      taxAmountStandard += lineTax;
+    }
+  });
+
+  const totalAmount =
+    subtotalAmount + taxAmountStandard + taxAmountReduced + taxAmountExempt;
+
+  return {
+    subtotalAmount,
+    taxAmountStandard,
+    taxAmountReduced,
+    taxAmountExempt,
+    totalAmount,
+  };
+}
+
+/**
+ * 税込価格から税抜価格を逆算
+ */
+export function calculateExclusivePrice(
+  inclusivePrice: number,
+  taxRate: number
+): number {
+  return Math.round((inclusivePrice * 100) / (100 + taxRate));
+}
+
+/**
+ * 並び順正規化（0から連番）
+ */
+export function normalizeSortOrder(
+  items: Array<{ id: string; sortOrder: number }>
+): Array<{ id: string; sortOrder: number }> {
+  return items
+    .sort((a, b) => a.sortOrder - b.sortOrder)
+    .map((item, index) => ({
+      ...item,
+      sortOrder: index,
+    }));
+}
+
+/**
+ * CSVデータのパース・バリデーション
+ */
+export function parseCSVData(csvContent: string): {
+  data: unknown[];
+  errors: Array<{ row: number; error: string }>;
+} {
+  const results = Papa.parse(csvContent, {
+    header: true,
+    skipEmptyLines: true,
+    transformHeader: (header) => header.trim(),
+  });
+
+  return {
+    data: results.data,
+    errors: results.errors.map((error) => ({
+      row: error.row ?? 0,
+      error: error.message,
+    })),
+  };
+}
+
+/**
+ * フォームエラーメッセージ生成（請求書用）
+ */
+export function generateInvoiceFormErrorMessage(
+  fieldName: string,
+  errorType: string
+): string {
+  const messages: Record<string, Record<string, string>> = {
+    clientId: {
+      required: 'クライアントを選択してください',
+      invalid: '有効なクライアントを選択してください',
+    },
+    issueDate: {
+      required: '発行日を入力してください',
+      invalid: '有効な発行日を入力してください',
+    },
+    dueDate: {
+      invalid: '有効な支払期限を入力してください',
+      beforeIssue: '支払期限は発行日以降である必要があります',
+    },
+    paymentDate: {
+      invalid: '有効な支払日を入力してください',
+      required: '支払済みステータスには支払日が必要です',
+    },
+  };
+
+  return messages[fieldName]?.[errorType] ?? 'エラーが発生しました';
+}
+
+/**
+ * 請求書品目フォームエラーメッセージ生成
+ */
+export function generateInvoiceItemFormErrorMessage(
+  fieldName: string,
+  errorType: string
+): string {
+  const messages: Record<string, Record<string, string>> = {
+    description: {
+      required: '品目名を入力してください',
+      minLength: '品目名は1文字以上である必要があります',
+    },
+    quantity: {
+      required: '数量を入力してください',
+      positive: '数量は正の数である必要があります',
+      invalid: '有効な数量を入力してください',
+    },
+    unitPrice: {
+      required: '単価を入力してください',
+      nonnegative: '単価は0以上である必要があります',
+      invalid: '有効な単価を入力してください',
+    },
+    discountAmount: {
+      nonnegative: '割引額は0以上である必要があります',
+      exceedsTotal: '割引額は品目合計金額を超えることはできません',
+      invalid: '有効な割引額を入力してください',
+    },
+    taxRate: {
+      min: '税率は0以上である必要があります',
+      max: '税率は100以下である必要があります',
+      invalid: '有効な税率を入力してください',
+    },
+  };
+
+  return messages[fieldName]?.[errorType] ?? 'エラーが発生しました';
+}
+
+/**
+ * 汎用エラーメッセージ生成
+ */
+export function generateErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  return '不明なエラーが発生しました';
+}
+
+/**
+ * フォームデータ前処理（請求書用）
+ */
+export function preprocessInvoiceFormData(
+  data: Record<string, unknown>
+): Record<string, unknown> {
+  const processed = { ...data };
+
+  // 空文字列をnullに変換
+  Object.keys(processed).forEach((key) => {
+    if (processed[key] === '') {
+      processed[key] = null;
+    }
+  });
+
+  // 日付フィールドの処理
+  if (processed.issueDate && typeof processed.issueDate === 'string') {
+    processed.issueDate = new Date(processed.issueDate);
+  }
+  if (processed.dueDate && typeof processed.dueDate === 'string') {
+    processed.dueDate = new Date(processed.dueDate);
+  }
+  if (processed.paymentDate && typeof processed.paymentDate === 'string') {
+    processed.paymentDate = new Date(processed.paymentDate);
+  }
+
+  return processed;
+}


### PR DESCRIPTION
## 概要

- 請求書の完全なCRUD API実装（作成・取得・更新・削除）
- 見積書から請求書への複製機能（選択的品目複製対応）
- 日本のインボイス制度準拠の税計算・番号管理システム

## 背景

- Issue #63 の実装要件に基づく請求書管理機能の追加
- 見積書から請求書への自然なワークフローを提供
- 法的要件（インボイス制度）への準拠

## 実装内容

### ドメイン層（lib/domains/invoices/）
- **schemas.ts**: Zodバリデーションスキーマ（作成・更新・検索）
- **types.ts**: TypeScript型定義とPrisma変換関数
- **utils.ts**: 請求書固有ユーティリティ（税計算・ステータス管理）
- **service.ts**: ビジネスロジック（CRUD操作・番号採番・楽観ロック）

### API層（app/api/invoices/）
- **route.ts**: メインCRUD API（GET一覧・POST作成）
- **[id]/route.ts**: 個別操作API（GET詳細・PUT更新・DELETE削除・PATCH支払）
- **search/route.ts**: 柔軟な検索API（フィルタ・ソート・ページネーション）
- **from-quote/[quoteId]/route.ts**: 見積書複製API（選択的品目複製）

### 主要機能
- **ステータス管理**: DRAFT→SENT→PAID/OVERDUEの遷移制御
- **番号採番**: I0001形式での自動採番（DRAFT→SENT遷移時）
- **税計算**: 複数税率対応・行別丸め・税区分管理
- **楽観ロック**: updatedAtによる競合制御
- **セキュリティ**: companyIdフィルタ強制・入力サニタイズ

## チェックリスト（必須確認事項）

- [x] 関連Issueにリンクされている
- [x] CIが通過している（test / lint / build）
- [x] 本番環境に影響がないことを確認済み
- [x] UI/UX上の重大な変更がある場合、他メンバーと共有済み
- [x] テストコードが追加 or テスト不要の理由を明記した

## 関連Issue / PR

- Close #63

## 補足

- 見積書ドメインの実装パターンを踏襲し、一貫性を保持
- セキュリティレビューで指摘された脆弱性をすべて修正済み
- 楽観ロック・バリデーション・エラーハンドリングを強化
- 2,700+行の実装で請求書管理の基盤完了