### PR TITLE
perf: PlaywrightコンテナでCI実行速度向上

### DIFF
--- a/.github/workflows/main-tests.yml
+++ b/.github/workflows/main-tests.yml
@@ -7,10 +7,13 @@ on:
 jobs:
   lint-unit-e2e-full:
     runs-on: ubuntu-latest
+    container: mcr.microsoft.com/playwright:v1.54.1-jammy
 
     env:
       NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
       CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+      # コンテナ内のプリインストール済みブラウザを使用し、ダウンロードを抑止
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
     steps:
       - uses: actions/checkout@v4
@@ -31,20 +34,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nextjs-
 
-      # Playwrightブラウザキャッシュ
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
-
       - run: npm run type-check
       - run: npm run lint
       - run: npm test
 
-      - run: npx playwright install --with-deps
       - run: npm run build
       - run: npx playwright test
 


### PR DESCRIPTION
## 概要

- CI環境でPlaywrightの実行速度を大幅改善
- ブラウザダウンロード時間を削減しE2Eテストを高速化

## 背景

- 現在のCIではPlaywrightブラウザのダウンロードに時間がかかっている
- 毎回のブラウザインストールがボトルネックとなっていた

## 実装内容

- Playwright公式コンテナ（mcr.microsoft.com/playwright:v1.54.1-jammy）を使用
- プリインストール済みブラウザでダウンロード処理を省略
- ブラウザキャッシュ設定とインストール処理を削除

## チェックリスト（必須確認事項）

- [x] 関連Issueにリンクされている
- [x] CIが通過している（test / lint / build）
- [x] 本番環境に影響がないことを確認済み
- [x] UI/UX上の重大な変更がある場合、他メンバーと共有済み
- [x] テストコードが追加 or テスト不要の理由を明記した

## 補足

CI設定の最適化のため、テストコード変更は不要です。