### PR TITLE
fix: Firefoxコンテナ権限エラー修正でHOME環境変数追加

### DIFF
--- a/.github/workflows/main-tests.yml
+++ b/.github/workflows/main-tests.yml
@@ -14,6 +14,7 @@ jobs:
       CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
       # コンテナ内のプリインストール済みブラウザを使用し、ダウンロードを抑止
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
+      HOME: /root
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## 概要

- CI環境でFirefoxが権限エラーで起動失敗する問題を修正
- PlaywrightコンテナでのHOMEディレクトリ権限問題を解決

## 背景

- mainブランチのCIでFirefoxテストが全て失敗していた
- コンテナ内のHOMEディレクトリ所有者権限エラーが原因

## 実装内容

- GitHub Actions workflow の環境変数に`HOME: /root`を追加
- Firefoxコンテナでの権限問題を解決

## チェックリスト（必須確認事項）

- [x] 関連Issueにリンクされている
- [x] CIが通過している（test / lint / build）
- [x] 本番環境に影響がないことを確認済み
- [x] UI/UX上の重大な変更がある場合、他メンバーと共有済み
- [x] テストコードが追加 or テスト不要の理由を明記した

## 補足

CI設定の修正のため、テストコード変更は不要です。